### PR TITLE
WIP: Reverses Chebyshev points, adds * transform and moves Fourier to [0,2π)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,18 @@
+
+# ApproxFun.jl NEWS
+
+#### notes on release changes, ongoing development, and future planned work
+
+
+## 0.4 (current master/development)
+
+
+#### 0.4.1
+- `PeriodicInterval()` now defaults to `PeriodicInterval(0,2π)`
+- `points(::Chebyshev,n)` has reversed the order
+- `Fun(cfs::Vector,sp::Space)` --> `Fun(sp::Space,cfs::Vector)`
+- `Interval(a,b)` --> `Segment(a,b)` when `a` and `b` are not real-valued
+- `Fun(f,[a,b])` --> `Fun(f,a..b)`, provided `a < b` are real-valued
+
+#### 0.4.0
+- Revamped PDE solving to use `qrfact`

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 
 #### 0.4.1
+- `transform(sp::Space,v,plan)` -> `plan*v`
 - `PeriodicInterval()` now defaults to `PeriodicInterval(0,2π)`
 - `points(::Chebyshev,n)` has reversed the order
 - `Fun(cfs::Vector,sp::Space)` --> `Fun(sp::Space,cfs::Vector)`

--- a/src/Domains/PeriodicInterval.jl
+++ b/src/Domains/PeriodicInterval.jl
@@ -50,19 +50,19 @@ Base.issubset(a::PeriodicInterval,b::PeriodicInterval) = first(a)∈b && a.b∈b
 ## Map periodic interval
 
 
-tocanonical{T}(d::PeriodicInterval{T},x)=π*(tocanonical(Segment(d),x)+1)
-tocanonicalD{T}(d::PeriodicInterval{T},x)=π*tocanonicalD(Segment(d),x)
+tocanonical{T}(d::PeriodicInterval{T},x) = π*(tocanonical(Segment(d),x)+1)
+tocanonicalD{T}(d::PeriodicInterval{T},x) = π*tocanonicalD(Segment(d),x)
 fromcanonical(d::PeriodicInterval,v::AbstractArray) = eltype(d)[fromcanonical(d,vk) for vk in v]
 fromcanonical{V<:Vec}(d::PeriodicInterval{V},p::AbstractArray) = V[fromcanonical(d,x) for x in p]
-fromcanonical(d::PeriodicInterval,θ)=fromcanonical(Segment(d),θ/π-1)
-fromcanonicalD(d::PeriodicInterval,θ)=fromcanonicalD(Segment(d),θ/π-1)/π
+fromcanonical(d::PeriodicInterval,θ) = fromcanonical(Segment(d),θ/π-1)
+fromcanonicalD(d::PeriodicInterval,θ) = fromcanonicalD(Segment(d),θ/π-1)/π
 
 
 
 arclength(d::PeriodicInterval) = norm(d.b - d.a)
 Base.angle(d::PeriodicInterval) = angle(d.b - d.a)
-complexlength(d::PeriodicInterval)=d.b-d.a
-Base.reverse(d::PeriodicInterval)=PeriodicInterval(d.b,d.a)
+complexlength(d::PeriodicInterval) = d.b-d.a
+Base.reverse(d::PeriodicInterval) = PeriodicInterval(d.b,d.a)
 
 
 
@@ -76,14 +76,14 @@ Base.reverse(d::PeriodicInterval)=PeriodicInterval(d.b,d.a)
 
 for op in (:*,:+,:-,:.*,:.+,:.-)
     @eval begin
-        $op(c::Number,d::PeriodicInterval)=PeriodicInterval($op(c,d.a),$op(c,d.b))
-        $op(d::PeriodicInterval,c::Number)=PeriodicInterval($op(d.a,c),$op(d.b,c))
+        $op(c::Number,d::PeriodicInterval) = PeriodicInterval($op(c,d.a),$op(c,d.b))
+        $op(d::PeriodicInterval,c::Number) = PeriodicInterval($op(d.a,c),$op(d.b,c))
     end
 end
 
 for op in (:/,:./)
-    @eval $op(d::PeriodicInterval,c::Number)=PeriodicInterval($op(d.a,c),$op(d.b,c))
+    @eval $op(d::PeriodicInterval,c::Number) = PeriodicInterval($op(d.a,c),$op(d.b,c))
 end
 
 
-+(d1::PeriodicInterval,d2::PeriodicInterval)=PeriodicInterval(d1.a+d2.a,d1.b+d2.b)
++(d1::PeriodicInterval,d2::PeriodicInterval) = PeriodicInterval(d1.a+d2.a,d1.b+d2.b)

--- a/src/Domains/PeriodicInterval.jl
+++ b/src/Domains/PeriodicInterval.jl
@@ -11,7 +11,7 @@ represents a periodic interval from `a` to `b`, that is, the point
 immutable PeriodicInterval{T} <: PeriodicDomain{T}
     a::T
     b::T
-    PeriodicInterval() = new(-convert(T,π),convert(T,π))
+    PeriodicInterval() = new(0,2convert(T,π))
     PeriodicInterval(a,b) = new(a,b)
 end
 
@@ -50,12 +50,12 @@ Base.issubset(a::PeriodicInterval,b::PeriodicInterval) = first(a)∈b && a.b∈b
 ## Map periodic interval
 
 
-tocanonical{T}(d::PeriodicInterval{T},x)=π*tocanonical(Segment(d),x)
+tocanonical{T}(d::PeriodicInterval{T},x)=π*(tocanonical(Segment(d),x)+1)
 tocanonicalD{T}(d::PeriodicInterval{T},x)=π*tocanonicalD(Segment(d),x)
 fromcanonical(d::PeriodicInterval,v::AbstractArray) = eltype(d)[fromcanonical(d,vk) for vk in v]
 fromcanonical{V<:Vec}(d::PeriodicInterval{V},p::AbstractArray) = V[fromcanonical(d,x) for x in p]
-fromcanonical(d::PeriodicInterval,θ)=fromcanonical(Segment(d),θ/π)
-fromcanonicalD(d::PeriodicInterval,θ)=fromcanonicalD(Segment(d),θ/π)/π
+fromcanonical(d::PeriodicInterval,θ)=fromcanonical(Segment(d),θ/π-1)
+fromcanonicalD(d::PeriodicInterval,θ)=fromcanonicalD(Segment(d),θ/π-1)/π
 
 
 

--- a/src/Domains/Point.jl
+++ b/src/Domains/Point.jl
@@ -42,6 +42,8 @@ Base.convert{PT<:Point}(::Type{PT},::AnyDomain) = PT(NaN)
 Base.norm(p::Point) = norm(p.x)
 
 Base.getindex(p::Point,k...) = p.x[k...]
+Base.first(p::Point) = p.x
+Base.last(p::Point) = p.x
 
 Base.in(x,d::Point) = isapprox(x,d.x)
 

--- a/src/Domains/ProductDomain.jl
+++ b/src/Domains/ProductDomain.jl
@@ -47,7 +47,7 @@ Base.transpose(d::ProductDomain)=ProductDomain(d[2],d[1])
 Base.getindex(d::ProductDomain,k::Integer)=d.domains[k]
 ==(d1::ProductDomain,d2::ProductDomain)=d1.domains==d2.domains
 
-Base.first(d::ProductDomain)=(first(d[1]),first(d[2]))
+Base.first(d::ProductDomain) = (first(d[1]),first(d[2]))
 
 Base.in(x::Vec,d::ProductDomain) = reduce(&,map(in,x,d.domains))
 

--- a/src/Extras/dualnumbers.jl
+++ b/src/Extras/dualnumbers.jl
@@ -23,22 +23,22 @@ valsdomain_type_promote{T<:Complex,V<:Real}(::Type{Dual{T}},::Type{Complex{V}}) 
 
 function plan_chebyshevtransform{D<:Dual}(v::Vector{D})
     plan = plan_chebyshevtransform(@compat(realpart.(v)))
-    ChebyshevTransformPlan{1,D,typeof(plan)}(plan)
+    ChebyshevTransformPlan{D,1,typeof(plan)}(plan)
 end
 
 function plan_ichebyshevtransform{D<:Dual}(v::Vector{D})
     plan = plan_ichebyshevtransform(@compat(realpart.(v)))
-    IChebyshevTransformPlan{1,D,typeof(plan)}(plan)
+    IChebyshevTransformPlan{D,1,typeof(plan)}(plan)
 end
 
 
 
 
 if VERSION < v"0.5"
-    *{k,D<:Dual}(P::ChebyshevTransformPlan{k,D},v::Vector{D}) =
+    *{k,D<:Dual}(P::ChebyshevTransformPlan{D,k},v::Vector{D}) =
         dual(P.plan*realpart(v),P.plan*dualpart(v))
 else
-    *{k,D<:Dual}(P::ChebyshevTransformPlan{k,D},v::Vector{D}) =
+    *{k,D<:Dual}(P::ChebyshevTransformPlan{D,k},v::Vector{D}) =
         dual.(P.plan*realpart.(v),P.plan*dualpart.(v))
 end
 

--- a/src/Extras/dualnumbers.jl
+++ b/src/Extras/dualnumbers.jl
@@ -50,16 +50,15 @@ else
 end
 
 #TODO: Hardy{false}
-for OP in (:plan_transform,:plan_itransform)
-    for TYP in  (:Fourier,:Laurent,:SinSpace)
-        @eval $OP{T<:Dual,D<:Domain}(S::$TYP{D},x::Vector{T}) = $OP(S,@compat(realpart.(x)))
-    end
-end
-
-for OP in (:transform,:itransform)
-    for TYP in (:Fourier,:Laurent,:SinSpace)
-        @eval $OP{T<:Dual,D<:Domain}(S::$TYP{D},x::Vector{T},plan) =
-            dual($OP(S,@compat(realpart.(x)),plan),$OP(S,@compat(dualpart.(x)),plan))
+for (OP,TransPlan) in ((:plan_transform,:TransformPlan),(:plan_itransform,:ITransformPlan)),
+        TYP in  (:Fourier,:Laurent,:SinSpace)
+    @eval begin
+        function $OP{T<:Dual,D<:Domain}(sp::$TYP{D},x::Vector{T})
+            plan = $OP(sp,@compat(realpart.(x)))
+            $TransPlan{T,typeof(sp),false,typeof(plan)}(sp,plan)
+        end
+        *{T<:Dual,D<:Domain}(P::$TransPlan{T,$TYP{D},false},x::Vector{T}) =
+            dual(P.plan*@compat(realpart.(x)),P.plan*@compat(dualpart.(x)))
     end
 end
 

--- a/src/Extras/dualnumbers.jl
+++ b/src/Extras/dualnumbers.jl
@@ -21,16 +21,25 @@ valsdomain_type_promote{T<:Complex,V<:Real}(::Type{Dual{T}},::Type{Complex{V}}) 
     Dual{promote_type(T,Complex{V})},Complex{promote_type(real(T),V)}
 
 
-for OP in (:plan_chebyshevtransform,:plan_ichebyshevtransform)
-    @eval $OP{D<:Dual}(v::Vector{D}) = $OP(@compat(realpart.(v)))
+function plan_chebyshevtransform{D<:Dual}(v::Vector{D})
+    plan = plan_chebyshevtransform(@compat(realpart.(v)))
+    ChebyshevTransformPlan{1,D,typeof(plan)}(plan)
 end
 
+function plan_ichebyshevtransform{D<:Dual}(v::Vector{D})
+    plan = plan_ichebyshevtransform(@compat(realpart.(v)))
+    IChebyshevTransformPlan{1,D,typeof(plan)}(plan)
+end
+
+
+
+
 if VERSION < v"0.5"
-    chebyshevtransform{D<:Dual}(v::Vector{D},plan...) =
-        dual(chebyshevtransform(realpart(v),plan...),chebyshevtransform(dualpart(v),plan...))
+    *{k,D<:Dual}(P::ChebyshevTransformPlan{k,D},v::Vector{D}) =
+        dual(P.plan*realpart(v),P.plan*dualpart(v))
 else
-    chebyshevtransform{D<:Dual}(v::Vector{D},plan...) =
-        dual.(chebyshevtransform(realpart.(v),plan...),chebyshevtransform(dualpart.(v),plan...))
+    *{k,D<:Dual}(P::ChebyshevTransformPlan{k,D},v::Vector{D}) =
+        dual.(P.plan*realpart.(v),P.plan*dualpart.(v))
 end
 
 #TODO: Hardy{false}

--- a/src/Extras/dualnumbers.jl
+++ b/src/Extras/dualnumbers.jl
@@ -21,14 +21,21 @@ valsdomain_type_promote{T<:Complex,V<:Real}(::Type{Dual{T}},::Type{Complex{V}}) 
     Dual{promote_type(T,Complex{V})},Complex{promote_type(real(T),V)}
 
 
-function plan_chebyshevtransform{D<:Dual}(v::Vector{D})
-    plan = plan_chebyshevtransform(@compat(realpart.(v)))
-    ChebyshevTransformPlan{D,1,typeof(plan)}(plan)
+plan_chebyshevtransform!{T<:Dual}(x::Vector{T};kind::Integer=1) =
+    error("In-place variant not implemented for Dual")
+
+plan_ichebyshevtransform!{T<:Dual}(x::Vector{T};kind::Integer=1) =
+    error("In-place variant not implemented for Dual")
+
+
+function plan_chebyshevtransform{D<:Dual}(v::Vector{D};kind::Integer=1)
+    plan = plan_chebyshevtransform(@compat(realpart.(v));kind=kind)
+    ChebyshevTransformPlan{D,kind,false,typeof(plan)}(plan)
 end
 
-function plan_ichebyshevtransform{D<:Dual}(v::Vector{D})
-    plan = plan_ichebyshevtransform(@compat(realpart.(v)))
-    IChebyshevTransformPlan{D,1,typeof(plan)}(plan)
+function plan_ichebyshevtransform{D<:Dual}(v::Vector{D};kind::Integer=1)
+    plan = plan_ichebyshevtransform(@compat(realpart.(v));kind=kind)
+    IChebyshevTransformPlan{D,kind,false,typeof(plan)}(plan)
 end
 
 

--- a/src/Extras/dualnumbers.jl
+++ b/src/Extras/dualnumbers.jl
@@ -42,10 +42,10 @@ end
 
 
 if VERSION < v"0.5"
-    *{k,D<:Dual}(P::ChebyshevTransformPlan{D,k},v::Vector{D}) =
+    *{k,D<:Dual}(P::ChebyshevTransformPlan{D,k,false},v::Vector{D}) =
         dual(P.plan*realpart(v),P.plan*dualpart(v))
 else
-    *{k,D<:Dual}(P::ChebyshevTransformPlan{D,k},v::Vector{D}) =
+    *{k,D<:Dual}(P::ChebyshevTransformPlan{D,k,false},v::Vector{D}) =
         dual.(P.plan*realpart.(v),P.plan*dualpart.(v))
 end
 

--- a/src/Extras/fftGeneric.jl
+++ b/src/Extras/fftGeneric.jl
@@ -39,13 +39,20 @@ Base.plan_ifft!{F<:Fun}(x::Vector{F}) = ifft
 
 # Chebyshev transforms and plans for BigFloats
 # no plan exists at the moment, so we make a dummy plan
+plan_chebyshevtransform!{T<:BigFloats}(x::Vector{T};kind::Integer=1) =
+    error("In-place variant not implemented for BigFloat")
+
+plan_ichebyshevtransform!{T<:BigFloats}(x::Vector{T};kind::Integer=1) =
+    error("In-place variant not implemented for BigFloat")
+
+
 plan_chebyshevtransform{T<:BigFloats}(x::Vector{T};kind::Integer=1) =
-    ChebyshevTransformPlan{kind,T,Void}(nothing)
+    ChebyshevTransformPlan{T,kind,false,Void}(nothing)
 plan_ichebyshevtransform{T<:BigFloats}(x::Vector{T};kind::Integer=1) =
-    IChebyshevTransformPlan{kind,T,Void}(nothing)
+    IChebyshevTransformPlan{T,kind,false,Void}(nothing)
 
 #following Chebfun's @Chebtech1/vals2coeffs.m and @Chebtech2/vals2coeffs.m
-function *{T<:BigFloats}(P::ChebyshevTransformPlan{1,T},x::Vector{T})
+function *{T<:BigFloats}(P::ChebyshevTransformPlan{T,1,false},x::Vector{T})
     n = length(x)
     if n == 1
         x
@@ -58,7 +65,7 @@ function *{T<:BigFloats}(P::ChebyshevTransformPlan{1,T},x::Vector{T})
     end
 end
 
-function *{T<:BigFloats}(P::ChebyshevTransformPlan{2,T},x::Vector{T})
+function *{T<:BigFloats}(P::ChebyshevTransformPlan{T,2,false},x::Vector{T})
     n = length(x)
     if n == 1
         x
@@ -71,7 +78,7 @@ function *{T<:BigFloats}(P::ChebyshevTransformPlan{2,T},x::Vector{T})
 end
 
 #following Chebfun's @Chebtech1/vals2coeffs.m and @Chebtech2/vals2coeffs.m
-function *{T<:BigFloats}(P::IChebyshevTransformPlan{1,T},x::Vector{T})
+function *{T<:BigFloats}(P::IChebyshevTransformPlan{T,1,false},x::Vector{T})
     n = length(x)
     if n == 1
         x
@@ -82,7 +89,7 @@ function *{T<:BigFloats}(P::IChebyshevTransformPlan{1,T},x::Vector{T})
         ret = T<:Real ? real(ret) : ret
     end
 end
-function *{T<:BigFloats}(P::IChebyshevTransformPlan{2,T},x::Vector{T})
+function *{T<:BigFloats}(P::IChebyshevTransformPlan{T,2,false},x::Vector{T})
     n = length(x)
     if n == 1
         x

--- a/src/Extras/fftGeneric.jl
+++ b/src/Extras/fftGeneric.jl
@@ -90,9 +90,8 @@ function ichebyshevtransform{T<:BigFloats}(x::Vector{T},plan;kind::Integer=1)
             ret = chebyshevtransform(x;kind=kind)
             x[1] /=2;x[end] /=2
             ret[1] *= 2;ret[end] *= 2
-            negateeven!(ret)
             ret *= .5*(n-1)
-            reverse!(ret)
+            ret
         end
     end
 end

--- a/src/Extras/roots.jl
+++ b/src/Extras/roots.jl
@@ -227,8 +227,8 @@ function rootsunit_coeffs{S,T<:Number}(c::Vector{T}, htol::Float64,clplan::Clens
 
         # Recurse (and map roots back to original interval):
         p = plan_chebyshevtransform( v1 )
-        r = [ (splitPoint - 1)/2 + (splitPoint + 1)/2*rootsunit_coeffs( chebyshevtransform(v1,p), 2*htol,clplan) ;
-                 (splitPoint + 1)/2 + (1 - splitPoint)/2*rootsunit_coeffs( chebyshevtransform(v2,p), 2*htol,clplan) ]
+        r = [ (splitPoint - 1)/2 + (splitPoint + 1)/2*rootsunit_coeffs( p*v1, 2*htol,clplan) ;
+                 (splitPoint + 1)/2 + (1 - splitPoint)/2*rootsunit_coeffs( p*v2, 2*htol,clplan) ]
 
     end
 

--- a/src/Fun/Domain.jl
+++ b/src/Fun/Domain.jl
@@ -109,10 +109,11 @@ abstract PeriodicDomain{T} <: UnivariateDomain{T}
 
 canonicaldomain(::PeriodicDomain)=PeriodicInterval()
 
-points{T}(d::PeriodicDomain{T},n::Integer) = fromcanonical(d, fourierpoints(real(eltype(eltype(T))),n))
+points{T}(d::PeriodicDomain{T},n::Integer) =
+    fromcanonical(d, fourierpoints(real(eltype(eltype(T))),n))
 
 fourierpoints(n::Integer) = fourierpoints(Float64,n)
-fourierpoints{T<:Number}(::Type{T},n::Integer)= convert(T,π)*collect(-n:2:n-2)/n
+fourierpoints{T<:Number}(::Type{T},n::Integer)= convert(T,π)*collect(0:2:2n-2)/n
 
 
 function Base.in{T}(x,d::PeriodicDomain{T})
@@ -132,8 +133,8 @@ end
 Base.issubset(a::Domain,b::Domain)=a==b
 
 
-Base.first(d::PeriodicDomain)=fromcanonical(d,-π)
-Base.last(d::PeriodicDomain)=fromcanonical(d,π)
+Base.first(d::PeriodicDomain) = fromcanonical(d,0)
+Base.last(d::PeriodicDomain) = fromcanonical(d,2π)
 
 
 immutable AnyPeriodicDomain <: PeriodicDomain{UnsetNumber} end

--- a/src/Fun/Domain.jl
+++ b/src/Fun/Domain.jl
@@ -124,9 +124,9 @@ function Base.in{T}(x,d::PeriodicDomain{T})
 
     l=arclength(d)
     if isinf(l)
-        abs(imag(y))<20eps(T) && -π-2eps(T)<real(y)<π+2eps(T)
+        abs(imag(y))<20eps(T) && -2eps(T)<real(y)<2π+2eps(T)
     else
-        abs(imag(y))/l<20eps(T) && -π-2l*eps(T)<real(y)<π+2l*eps(T)
+        abs(imag(y))/l<20eps(T) && -2l*eps(T)<real(y)<2π+2l*eps(T)
     end
 end
 

--- a/src/Fun/Domain.jl
+++ b/src/Fun/Domain.jl
@@ -181,7 +181,7 @@ Base.rand(d::IntervalDomain,k...)=fromcanonical(d,2rand(k...)-1)
 Base.rand(d::PeriodicDomain,k...)=fromcanonical(d,2π*rand(k...)-π)
 
 checkpoints(d::IntervalDomain) = fromcanonical(d,[-0.823972,0.01,0.3273484])
-checkpoints(d::PeriodicDomain) = fromcanonical(d,[0.01,1.223972,5.83273484])
+checkpoints(d::PeriodicDomain) = fromcanonical(d,[1.223972,3.14,5.83273484])
 
 ## boundary
 

--- a/src/Fun/Domain.jl
+++ b/src/Fun/Domain.jl
@@ -66,12 +66,12 @@ domainscompatible(a::Domain,b::Domain) = isambiguous(a) || isambiguous(b) ||
 
 function chebyshevpoints{T<:Number}(::Type{T},n::Integer;kind::Integer=1)
     if kind == 1
-        T[sinpi((n-2k-one(T))/2n) for k=n-1:-1:0]
+        T[sinpi((n-2k-one(T))/2n) for k=0:n-1]
     elseif kind == 2
         if n==1
             zeros(T,1)
         else
-            T[cospi(k/(n-one(T))) for k=n-1:-1:0]
+            T[cospi(k/(n-one(T))) for k=0:n-1]
         end
     end
 end

--- a/src/Fun/Domain.jl
+++ b/src/Fun/Domain.jl
@@ -181,7 +181,7 @@ Base.rand(d::IntervalDomain,k...)=fromcanonical(d,2rand(k...)-1)
 Base.rand(d::PeriodicDomain,k...)=fromcanonical(d,2π*rand(k...)-π)
 
 checkpoints(d::IntervalDomain) = fromcanonical(d,[-0.823972,0.01,0.3273484])
-checkpoints(d::PeriodicDomain) = fromcanonical(d,[1.223972,0.01,-2.83273484])
+checkpoints(d::PeriodicDomain) = fromcanonical(d,[0.01,1.223972,5.83273484])
 
 ## boundary
 

--- a/src/Fun/Space.jl
+++ b/src/Fun/Space.jl
@@ -461,29 +461,27 @@ for Typ in (:CanonicalTransformPlan,:ICanonicalTransformPlan)
         end
         $Typ(space,plan,csp) =
             $Typ{eltype(plan),typeof(space),typeof(plan),typeof(csp)}(space,plan,csp)
+        $Typ{T}(::Type{T},space,plan,csp) =
+            $Typ{T,typeof(space),typeof(plan),typeof(csp)}(space,plan,csp)
     end
-end
-
-function CanonicalTransformPlan(space,vals)
-    csp = canonicalspace(space)
-    CanonicalTransformPlan(space,plan_transform(csp,vals),csp)
-end
-
-function ICanonicalTransformPlan(space,vals)
-    csp = canonicalspace(space)
-    CanonicalTransformPlan(space,plan_itransform(csp,vals),csp)
 end
 
 
 # Canonical plan uses coefficients
 for (pl,CTransPlan) in ((:plan_transform,:CanonicalTransformPlan),
                              (:plan_itransform,:ICanonicalTransformPlan))
-    @eval function $pl(sp::Space,vals)
-        csp = canonicalspace(sp)
-        if sp == csp
-            error("Override for $sp")
+    @eval begin
+        function $CTransPlan(space,v)
+            csp = canonicalspace(space)
+            $CTransPlan(eltype(v),space,$pl(csp,v),csp)
         end
-        $CTransPlan(sp,$pl(csp,vals),csp)
+        function $pl(sp::Space,vals)
+            csp = canonicalspace(sp)
+            if sp == csp
+                error("Override for $sp")
+            end
+            $CTransPlan(sp,$pl(csp,vals),csp)
+        end
     end
 end
 

--- a/src/Fun/Space.jl
+++ b/src/Fun/Space.jl
@@ -440,6 +440,20 @@ checkpoints(d::Space) = checkpoints(domain(d))
 
 ## default transforms
 
+# These plans are use to wrap another plan
+for Typ in (:TransformPlan,:ITransformPlan)
+    @eval begin
+        immutable $Typ{T,SP,inplace,PL} <: FFTW.Plan{T}
+            space::SP
+            plan::PL
+        end
+        $Typ{inplace}(space,plan,::Type{Val{inplace}}) =
+            $Typ{eltype(plan),typeof(space),inplace,typeof(plan)}(space,plan)
+    end
+end
+
+
+
 # transform converts from values at points(S,n) to coefficients
 # itransform converts from coefficients to values at points(S,n)
 

--- a/src/Fun/Space.jl
+++ b/src/Fun/Space.jl
@@ -452,57 +452,62 @@ for Typ in (:TransformPlan,:ITransformPlan)
     end
 end
 
+for Typ in (:CanonicalTransformPlan,:ICanonicalTransformPlan)
+    @eval begin
+        immutable $Typ{T,SP,PL,CSP} <: FFTW.Plan{T}
+            space::SP
+            plan::PL
+            canonicalspace::CSP
+        end
+        $Typ(space,plan,csp) =
+            $Typ{eltype(plan),typeof(space),typeof(plan),typeof(csp)}(space,plan,csp)
+    end
+end
+
+function CanonicalTransformPlan(space,vals)
+    csp = canonicalspace(space)
+    CanonicalTransformPlan(space,plan_transform(csp,vals),csp)
+end
+
+function ICanonicalTransformPlan(space,vals)
+    csp = canonicalspace(space)
+    CanonicalTransformPlan(space,plan_itransform(csp,vals),csp)
+end
+
+
+# Canonical plan uses coefficients
+for (pl,CTransPlan) in ((:plan_transform,:CanonicalTransformPlan),
+                             (:plan_itransform,:ICanonicalTransformPlan))
+    @eval function $pl(sp::Space,vals)
+        csp = canonicalspace(sp)
+        if sp == csp
+            error("Override for $sp")
+        end
+        $CTransPlan(sp,$pl(csp,vals),csp)
+    end
+end
+
+plan_transform!(sp::Space,vals) = error("Override for $sp")
+plan_itransform!(sp::Space,cfs) = error("Override for $sp")
+
 
 
 # transform converts from values at points(S,n) to coefficients
 # itransform converts from coefficients to values at points(S,n)
 
-transform(S::Space,vals) = transform(S,vals,plan_transform(S,vals))
-itransform(S::Space,cfs) = itransform(S,cfs,plan_itransform(S,cfs))
+transform(S::Space,vals) = plan_transform(S,vals)*vals
+itransform(S::Space,cfs) = plan_itransform(S,cfs)*cfs
 
-function transform(S::Space,vals,plan)
-    csp=canonicalspace(S)
-    if S==csp
-        error("Override transform(::"*string(typeof(S))*",vals,plan)")
-    end
-
-    coefficients(transform(csp,vals,plan),csp,S)
-end
-
-function itransform(S::Space,cfs,plan)
-    csp=canonicalspace(S)
-    if S==csp
-        error("Override itransform(::"*string(typeof(S))*",cfs,plan)")
-    end
-
-    itransform(csp,coefficients(cfs,S,csp),plan)
-end
+*(P::CanonicalTransformPlan,vals::Vector) = coefficients(P.plan*vals,P.canonicalspace,P.space)
+*(P::ICanonicalTransformPlan,cfs::Vector) = P.plan*coefficients(cfs,P.space,P.canonicalspace)
 
 
-for OP in (:plan_transform,:plan_itransform)
+
+for OP in (:plan_transform,:plan_itransform,:plan_transform!,:plan_itransform!)
     # plan transform expects a vector
     # this passes an empty Float64 array
-    @eval $OP(S::Space,n::Integer)=$OP(S,Array(Float64,n))
+    @eval $OP(S::Space,n::Integer) = $OP(S,Array(Float64,n))
 end
-
-function plan_transform(S::Space,vals)
-    csp=canonicalspace(S)
-    if S==csp
-        identity #TODO: why identity?
-    else
-        plan_transform(csp,vals)
-    end
-end
-
-function plan_itransform(S::Space,cfs)
-    csp=canonicalspace(S)
-    if S==csp
-        identity #TODO: why identity?
-    else
-        plan_itransform(csp,cfs)
-    end
-end
-
 
 ## sorting
 # we sort spaces lexigraphically by default
@@ -531,9 +536,8 @@ ConstantSpace() = ConstantSpace(AnyDomain())
 
 isconstspace(::ConstantSpace) = true
 
-function transform(sp::ConstantSpace,vals,plan...)
-    @assert length(vals)==1
-    vals
+for pl in (:plan_transform,:plan_transform!,:plan_itransform,:plan_itransform!)
+    @eval $pl(sp::ConstantSpace,vals) = I
 end
 
 # we override maxspace instead of maxspace_rule to avoid

--- a/src/LinearAlgebra/chebyshevtransform.jl
+++ b/src/LinearAlgebra/chebyshevtransform.jl
@@ -21,7 +21,7 @@ function chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer=
         if n == 1
             x
         else
-            ret=negateeven!(plan*x)
+            ret=plan*x
             ret[1]/=2
             scale!(inv(T(n)),ret)
         end
@@ -32,12 +32,12 @@ function chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer=
         else
             ret = plan*x
             ret[1] /= 2;ret[end] /= 2
-            negateeven!(ret)
             scale!(inv(T(n-1)),ret)
         end
     end
 end
-chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)=chebyshevtransform(x,plan_chebyshevtransform(x;kind=kind);kind=kind)
+chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1) =
+    chebyshevtransform(x,plan_chebyshevtransform(x;kind=kind);kind=kind)
 
 ## Inverse transforms take Chebyshev coefficients and produce values at Chebyshev points of the first and second kinds
 
@@ -60,8 +60,7 @@ end
 function ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer=1)
     if kind == 1
         x[1] *=2
-        ret = scale!(T(0.5),plan*negateeven!(x))
-        negateeven!(x)
+        ret = scale!(T(0.5),plan*x)
         x[1]/=2
         ret
     elseif kind == 2
@@ -74,18 +73,17 @@ function ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer
             ret = chebyshevtransform(x,plan;kind=kind)
             x[1] /=2;x[end] /=2
             ret[1] *= 2;ret[end] *= 2
-            negateeven!(ret)
             scale!(T(.5(n-1)),ret)
-            reverse!(ret)
         end
     end
 end
-ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)=ichebyshevtransform(x,plan_ichebyshevtransform(x;kind=kind);kind=kind)
+ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1) =
+    ichebyshevtransform(x,plan_ichebyshevtransform(x;kind=kind);kind=kind)
 
 ## Code generation for integer inputs
 
 for func in (:chebyshevtransform,:ichebyshevtransform)
-    @eval $func{T<:Integer}(x::Vector{T};kind::Integer=1)=$func(float64(x);kind=kind)
+    @eval $func{T<:Integer}(x::Vector{T};kind::Integer=1) = $func(float64(x);kind=kind)
 end
 
 
@@ -97,7 +95,7 @@ function chebyshevtransform{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
         if size(X) == (1,1)
             X
         else
-            R=negateeven!(FFTW.r2r(X,FFTW.REDFT10))
+            R=FFTW.r2r(X,FFTW.REDFT10)
             R[:,1]/=2;R[1,:]/=2;
             R/=size(X,1)*size(X,2)
         end
@@ -108,7 +106,7 @@ function chebyshevtransform{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
             R=FFTW.r2r(X,FFTW.REDFT00)/((size(X,1)-1)*(size(X,2)-1))
             R[:,1]/=2;R[:,end]/=2
             R[1,:]/=2;R[end,:]/=2
-            negateeven!(R)
+            R
         end
     end
 end
@@ -119,8 +117,7 @@ function ichebyshevtransform{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
             X
         else
             X[1,:]*=2;X[:,1]*=2
-            R = FFTW.r2r(negateeven!(X),FFTW.REDFT01)/4
-            negateeven!(X)
+            R = FFTW.r2r(X,FFTW.REDFT01)/4
             X[1,:]/=2;X[:,1]/=2
             R
         end
@@ -132,9 +129,8 @@ function ichebyshevtransform{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
             R=chebyshevtransform(X;kind=kind)
             X[1,:]/=2;X[end,:]/=2;X[:,1]/=2;X[:,end]/=2
             R[1,:]*=2;R[end,:]*=2;R[:,1]*=2;R[:,end]*=2
-            negateeven!(R)
             R*=(size(X,1)-1)*(size(X,2)-1)/4
-            flipud(fliplr(R))
+            R
         end
     end
 end

--- a/src/LinearAlgebra/chebyshevtransform.jl
+++ b/src/LinearAlgebra/chebyshevtransform.jl
@@ -5,37 +5,42 @@ export plan_chebyshevtransform, plan_ichebyshevtransform, chebyshevtransform, ic
 #TODO confirm that this can handle T=Complex{Float64} looks like this is a real-to-real transform
 
 
-immutable ChebyshevTransformPlan{kind,T,P}
+immutable ChebyshevTransformPlan{T,kind,inplace,P} <: FFTW.Plan{T}
     plan::P
 end
 
 
 
-function plan_chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
+function plan_chebyshevtransform!{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
     if kind == 1
-        plan = FFTW.plan_r2r(x, FFTW.REDFT10)
-        ChebyshevTransformPlan{1,T,typeof(plan)}(plan)
+        plan = FFTW.plan_r2r!(x, FFTW.REDFT10)
+        ChebyshevTransformPlan{T,1,true,typeof(plan)}(plan)
     elseif kind == 2
         if length(x) ≤ 1
             error("Cannot create a length $(length(x)) chebyshev transform")
         end
-        plan = FFTW.plan_r2r(x, FFTW.REDFT00)
-        ChebyshevTransformPlan{2,T,typeof(plan)}(plan)
+        plan = FFTW.plan_r2r!(x, FFTW.REDFT00)
+        ChebyshevTransformPlan{T,2,true,typeof(plan)}(plan)
     end
 end
 
-function *{T}(P::ChebyshevTransformPlan{1},x::Vector{T})
+function plan_chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
+    plan = plan_chebyshevtransform!(x;kind=kind)
+    ChebyshevTransformPlan{T,kind,false,typeof(plan)}(plan)
+end
+
+function *{T}(P::ChebyshevTransformPlan{T,1,true},x::Vector{T})
     n = length(x)
     if n == 1
         x
     else
-        ret = P.plan*x
-        ret[1]/=2
-        scale!(inv(T(n)),ret)
+        x = P.plan*x
+        x[1]/=2
+        scale!(inv(T(n)),x)
     end
 end
 
-function *{T}(P::ChebyshevTransformPlan{2},x::Vector{T})
+function *{T}(P::ChebyshevTransformPlan{T,2,true},x::Vector{T})
     n = length(x)
     if n == 1
         x
@@ -44,62 +49,73 @@ function *{T}(P::ChebyshevTransformPlan{2},x::Vector{T})
         if n == 1
             x
         else
-            ret = P.plan*x
-            ret[1] /= 2;ret[end] /= 2
-            scale!(inv(T(n-1)),ret)
+            x = P.plan*x
+            x[1] /= 2;x[end] /= 2
+            scale!(inv(T(n-1)),x)
         end
     end
 end
 
-chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1) =
-    plan_chebyshevtransform(x;kind=kind)*x
+chebyshevtransform!{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1) =
+    plan_chebyshevtransform!(x;kind=kind)*x
+
+chebyshevtransform(x;kind::Integer=1) = chebyshevtransform!(copy(x);kind=kind)
+
+*{T,k}(P::ChebyshevTransformPlan{T,k,false},x::Vector{T}) = P.plan*copy(x)
 
 ## Inverse transforms take Chebyshev coefficients and produce values at Chebyshev points of the first and second kinds
 
 
-immutable IChebyshevTransformPlan{kind,T,P}
+immutable IChebyshevTransformPlan{T,kind,inplace,P}
     plan::P
 end
 
-function plan_ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
+function plan_ichebyshevtransform!{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
     if kind == 1
         if length(x) == 0
             error("Cannot create a length 0 inverse chebyshev transform")
         end
-        plan = FFTW.plan_r2r(x, FFTW.REDFT01)
-        IChebyshevTransformPlan{1,T,typeof(plan)}(plan)
+        plan = FFTW.plan_r2r!(x, FFTW.REDFT01)
+        IChebyshevTransformPlan{T,1,true,typeof(plan)}(plan)
     elseif kind == 2
         if length(x) ≤ 1
             error("Cannot create a length $(length(x)) inverse chebyshev transform")
         end
-        plan = plan_chebyshevtransform(x;kind=2)
-        IChebyshevTransformPlan{2,T,typeof(plan)}(plan)
+        plan = plan_chebyshevtransform!(x;kind=2)
+        IChebyshevTransformPlan{T,2,true,typeof(plan)}(plan)
     end
 end
 
-function *{T<:FFTW.fftwNumber}(P::IChebyshevTransformPlan{1},x::Vector{T})
-    x[1] *=2
-    ret = scale!(T(0.5),P.plan*x)
-    x[1]/=2
-    ret
+function plan_ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
+    plan = plan_ichebyshevtransform!(x;kind=kind)
+    IChebyshevTransformPlan{T,kind,false,typeof(plan)}(plan)
 end
 
-function *{T<:FFTW.fftwNumber}(P::IChebyshevTransformPlan{2},x::Vector{T})
+function *{T<:FFTW.fftwNumber}(P::IChebyshevTransformPlan{T,1,true},x::Vector{T})
+    x[1] *=2
+    x = scale!(T(0.5),P.plan*x)
+    x
+end
+
+function *{T<:FFTW.fftwNumber}(P::IChebyshevTransformPlan{T,2,true},x::Vector{T})
     n = length(x)
     if n == 1
         x
     else
         ##TODO: make thread safe
         x[1] *= 2;x[end] *= 2
-        ret = P.plan*x
-        x[1] /=2;x[end] /=2
-        ret[1] *= 2;ret[end] *= 2
-        scale!(T(.5(n-1)),ret)
+        x = P.plan*x
+        x[1] *= 2;x[end] *= 2
+        scale!(T(.5(n-1)),x)
     end
 end
 
-ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1) =
-    plan_ichebyshevtransform(x;kind=kind)*x
+ichebyshevtransform!{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1) =
+    plan_ichebyshevtransform!(x;kind=kind)*x
+
+ichebyshevtransform(x;kind::Integer=1) = ichebyshevtransform!(copy(x);kind=kind)
+
+*{T,k}(P::IChebyshevTransformPlan{T,k,false},x::Vector{T}) = P.plan*copy(x)
 
 ## Code generation for integer inputs
 
@@ -111,47 +127,45 @@ end
 # Matrix inputs
 
 
-function chebyshevtransform{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
+function chebyshevtransform!{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
     if kind == 1
         if size(X) == (1,1)
             X
         else
-            R=FFTW.r2r(X,FFTW.REDFT10)
-            R[:,1]/=2;R[1,:]/=2;
-            R/=size(X,1)*size(X,2)
+            X=FFTW.r2r!(X,FFTW.REDFT10)
+            X[:,1]/=2;X[1,:]/=2;
+            scale!(1/(size(X,1)*size(X,2)),X)
         end
     elseif kind == 2
         if size(X) == (1,1)
             X
         else
-            R=FFTW.r2r(X,FFTW.REDFT00)/((size(X,1)-1)*(size(X,2)-1))
-            R[:,1]/=2;R[:,end]/=2
-            R[1,:]/=2;R[end,:]/=2
-            R
+            X=FFTW.r2r!(X,FFTW.REDFT00)
+            scale!(1/((size(X,1)-1)*(size(X,2)-1)),X)
+            X[:,1]/=2;X[:,end]/=2
+            X[1,:]/=2;X[end,:]/=2
+            X
         end
     end
 end
 
-function ichebyshevtransform{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
+function ichebyshevtransform!{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
     if kind == 1
         if size(X) == (1,1)
             X
         else
             X[1,:]*=2;X[:,1]*=2
-            R = FFTW.r2r(X,FFTW.REDFT01)/4
-            X[1,:]/=2;X[:,1]/=2
-            R
+            X = FFTW.r2r(X,FFTW.REDFT01)
+            scale!(1/4,X)
         end
     elseif kind == 2
         if size(X) == (1,1)
             X
         else
             X[1,:]*=2;X[end,:]*=2;X[:,1]*=2;X[:,end]*=2
-            R=chebyshevtransform(X;kind=kind)
-            X[1,:]/=2;X[end,:]/=2;X[:,1]/=2;X[:,end]/=2
-            R[1,:]*=2;R[end,:]*=2;R[:,1]*=2;R[:,end]*=2
-            R*=(size(X,1)-1)*(size(X,2)-1)/4
-            R
+            X=chebyshevtransform!(X;kind=kind)
+            X[1,:]*=2;X[end,:]*=2;X[:,1]*=2;X[:,end]*=2
+            scale!((size(X,1)-1)*(size(X,2)-1)/4,X)
         end
     end
 end

--- a/src/LinearAlgebra/chebyshevtransform.jl
+++ b/src/LinearAlgebra/chebyshevtransform.jl
@@ -9,24 +9,27 @@ immutable ChebyshevTransformPlan{T,kind,inplace,P} <: FFTW.Plan{T}
     plan::P
 end
 
+@compat (::Type{ChebyshevTransformPlan{k,inp}}){k,inp}(plan) =
+    ChebyshevTransformPlan{eltype(plan),k,inp,typeof(plan)}(plan)
+
 
 
 function plan_chebyshevtransform!{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
     if kind == 1
         plan = FFTW.plan_r2r!(x, FFTW.REDFT10)
-        ChebyshevTransformPlan{T,1,true,typeof(plan)}(plan)
+        ChebyshevTransformPlan{1,true}(plan)
     elseif kind == 2
         if length(x) ≤ 1
             error("Cannot create a length $(length(x)) chebyshev transform")
         end
         plan = FFTW.plan_r2r!(x, FFTW.REDFT00)
-        ChebyshevTransformPlan{T,2,true,typeof(plan)}(plan)
+        ChebyshevTransformPlan{2,true}(plan)
     end
 end
 
 function plan_chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
     plan = plan_chebyshevtransform!(x;kind=kind)
-    ChebyshevTransformPlan{T,kind,false,typeof(plan)}(plan)
+    ChebyshevTransformPlan{kind,false}(plan)
 end
 
 function *{T}(P::ChebyshevTransformPlan{T,1,true},x::Vector{T})

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -425,43 +425,6 @@ function interlace!(v::Vector,offset::Int)
     v
 end
 
-## svfft
-
-##FFT That interlaces coefficients
-
-plan_svfft(x::Vector) = plan_fft(x)
-plan_isvfft(x::Vector) = plan_ifft(x)
-
-svfft{T}(v::Vector{T}) = svfft(v,plan_svfft(v))
-
-function svfft{T}(v::Vector{T},plan)
-    n = length(v)
-    v = scale!(inv(T(n)),plan*v)
-    if mod(n,2) == 0
-        reverseeven!(interlace!(v,1))
-    else
-        reverseeven!(interlace!(copy(v),1))
-    end
-end
-
-isvfft{T}(v::Vector{T}) = isvfft(v,plan_isvfft(v))
-
-function isvfft(sv::Vector,plan)
-    n = length(sv)
-
-    if mod(n,2) == 0
-        v=[sv[1:2:end];flipdim(sv[2:2:end],1)]
-    elseif mod(n,4)==3
-        v=[sv[1:2:end];
-           -flipdim(sv[2:2:end],1)]
-    else #mod(length(v),4)==1
-        v=[sv[1:2:end];
-           flipdim(sv[2:2:end],1)]
-    end
-
-    plan*scale!(n,v)
-end
-
 ## slnorm gives the norm of a slice of a matrix
 
 function slnorm(u::AbstractMatrix,r::Range,::Colon)

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -438,9 +438,9 @@ function svfft{T}(v::Vector{T},plan)
     n = length(v)
     v = scale!(inv(T(n)),plan*v)
     if mod(n,2) == 0
-        reverseeven!(interlace!(alternatesign!(v),1))
+        reverseeven!(interlace!(v,1))
     else
-        negateeven!(reverseeven!(interlace!(alternatesign!(copy(v)),1)))
+        reverseeven!(interlace!(copy(v),1))
     end
 end
 
@@ -450,13 +450,13 @@ function isvfft(sv::Vector,plan)
     n = length(sv)
 
     if mod(n,2) == 0
-        v=alternatesign!([sv[1:2:end];flipdim(sv[2:2:end],1)])
+        v=[sv[1:2:end];flipdim(sv[2:2:end],1)]
     elseif mod(n,4)==3
-        v=[alternatesign!(sv[1:2:end]);
-           -alternatesign!(flipdim(sv[2:2:end],1))]
+        v=[sv[1:2:end];
+           -flipdim(sv[2:2:end],1)]
     else #mod(length(v),4)==1
-        v=[alternatesign!(sv[1:2:end]);
-           alternatesign!(flipdim(sv[2:2:end],1))]
+        v=[sv[1:2:end];
+           flipdim(sv[2:2:end],1)]
     end
 
     plan*scale!(n,v)

--- a/src/Multivariate/LowRankFun.jl
+++ b/src/Multivariate/LowRankFun.jl
@@ -120,7 +120,7 @@ function standardLowRankFun(f::Function,dx::Space,dy::Space;tolerance::Union{Sym
         for j=1:gridy
             @inbounds Bvals[j] = f(r[1],ptsy[j])
         end
-        a,b = Fun(dx,transform(dx,Avals,p₁)) - dotu(Br,A),Fun(dy,transform(dy,Bvals,p₂)) - dotu(Ar,B)
+        a,b = Fun(dx,p₁*Avals) - dotu(Br,A),Fun(dy,p₂*Bvals) - dotu(Ar,B)
         chop!(a,tol10),chop!(b,tol10)
     end
     warn("Maximum rank of " * string(maxrank) * " reached")
@@ -169,7 +169,7 @@ function CholeskyLowRankFun(f::Function,dx::Space;tolerance::Union{Symbol,Tuple{
         for i=1:grid
             @inbounds Avals[i] = f(pts[i],r)
         end
-        a = Fun(dx,transform(dx,Avals,p₁)) - dotu(Br,A)
+        a = Fun(dx,p₁*Avals) - dotu(Br,A)
         chop!(a,tol10)
     end
     warn("Maximum rank of " * string(maxrank) * " reached")

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -330,12 +330,12 @@ function itransform!(S::TensorSpace,M::Matrix)
 
     planc=plan_itransform(space(S,1),M[:,1])
     for k=1:size(M,2)
-        M[:,k]=itransform(space(S,1),M[:,k],planc)
+        M[:,k] = planc*M[:,k]
     end
 
     planr=plan_itransform(space(S,2),vec(M[1,:]))
     for k=1:n
-        M[k,:]=itransform(space(S,2),vec(M[k,:]),planr)
+        M[k,:]=planr*vec(M[k,:])
     end
     M
 end
@@ -360,12 +360,12 @@ function transform!(S::TensorSpace,M::Matrix)
 
     planc=plan_transform(space(S,1),M[:,1])
     for k=1:size(M,2)
-        M[:,k]=transform(space(S,1),M[:,k],planc)
+        M[:,k]=planc*M[:,k]
     end
 
     planr=plan_transform(space(S,2),vec(M[1,:]))
     for k=1:n
-        M[k,:]=transform(space(S,2),vec(M[k,:]),planr)
+        M[k,:]=planr*vec(M[k,:])
     end
     M
 end
@@ -481,7 +481,7 @@ function points(sp::TensorSpace,n)
     pts
 end
 
-function transform(sp::TensorSpace,vals,plan...)
+function transform(sp::TensorSpace,vals)
     NM=length(vals)
     if isfinite(dimension(sp[1])) && isfinite(dimension(sp[2]))
         N,M=dimension(sp[1]),dimension(sp[2])

--- a/src/Spaces/Chebyshev/Chebyshev.jl
+++ b/src/Spaces/Chebyshev/Chebyshev.jl
@@ -50,8 +50,8 @@ end
 
 ## Transform
 
-transform(::Chebyshev,vals::Vector,plan) = chebyshevtransform(vals,plan)
-itransform(::Chebyshev,cfs::Vector,plan) = ichebyshevtransform(cfs,plan)
+transform(::Chebyshev,vals::Vector,plan) = plan*vals
+itransform(::Chebyshev,cfs::Vector,plan) = plan*cfs
 plan_transform(::Chebyshev,vals::Vector) = plan_chebyshevtransform(vals)
 plan_itransform(::Chebyshev,cfs::Vector) = plan_ichebyshevtransform(cfs)
 

--- a/src/Spaces/Fourier/Fourier.jl
+++ b/src/Spaces/Fourier/Fourier.jl
@@ -144,8 +144,8 @@ horner(c::AbstractVector,kr::Range{Int64},x::AbstractArray) = reshape(horner(c,k
 points(sp::CosSpace,n) = points(domain(sp),2n-2)[n:-1:1]  #TODO: reorder Fourier
 plan_transform(::CosSpace,x::Vector) = plan_chebyshevtransform(x;kind=2)
 plan_itransform(::CosSpace,x::Vector) = plan_ichebyshevtransform(x;kind=2)
-transform(::CosSpace,vals,plan) = chebyshevtransform(vals,plan;kind=2)
-itransform(::CosSpace,cfs,plan) = ichebyshevtransform(cfs,plan;kind=2)
+transform(::CosSpace,vals,plan) = plan*vals
+itransform(::CosSpace,cfs,plan) = plan*cfs
 evaluate(f::Vector,S::CosSpace,t) = clenshaw(Chebyshev(),f,cos(tocanonical(S,t)))
 
 

--- a/src/Spaces/Fourier/Fourier.jl
+++ b/src/Spaces/Fourier/Fourier.jl
@@ -141,7 +141,7 @@ horner(c::AbstractVector,kr::Range{Int64},x::AbstractArray) = reshape(horner(c,k
 
 ## Cos and Sin space
 
-points(sp::CosSpace,n) = points(domain(sp),2n-2)[1:n]
+points(sp::CosSpace,n) = points(domain(sp),2n-2)[n:-1:1]  #TODO: reorder Fourier
 plan_transform(::CosSpace,x::Vector) = plan_chebyshevtransform(x;kind=2)
 plan_itransform(::CosSpace,x::Vector) = plan_ichebyshevtransform(x;kind=2)
 transform(::CosSpace,vals,plan) = chebyshevtransform(vals,plan;kind=2)

--- a/src/Spaces/Fourier/Fourier.jl
+++ b/src/Spaces/Fourier/Fourier.jl
@@ -330,7 +330,7 @@ points{D}(sp::Fourier{D},n)=points(domain(sp),n)
 plan_transform!{T<:FFTW.fftwNumber,D}(sp::Fourier{D},x::Vector{T}) =
     TransformPlan(sp,FFTW.plan_r2r!(x, FFTW.R2HC),Val{true})
 plan_itransform!{T<:FFTW.fftwNumber,D}(sp::Fourier{D},x::Vector{T}) =
-    TransformPlan(sp,FFTW.plan_r2r!(x, FFTW.HC2R),Val{true})
+    ITransformPlan(sp,FFTW.plan_r2r!(x, FFTW.HC2R),Val{true})
 
 for (Typ,Pltr!,Pltr) in ((:TransformPlan,:plan_transform!,:plan_transform),
                          (:ITransformPlan,:plan_itransform!,:plan_itransform))
@@ -360,7 +360,7 @@ end
 
 function *{T,DD}(P::ITransformPlan{T,Fourier{DD},true},cfs::Vector{T})
     n = length(cfs)
-    reverseeven!(negativeeven!(cfs))
+    reverseeven!(negateeven!(cfs))
     cfs[:] = [cfs[1:2:end];cfs[2:2:end]]
     if iseven(n)
         cfs[n÷2+1] *= 2

--- a/src/Spaces/Fourier/Fourier.jl
+++ b/src/Spaces/Fourier/Fourier.jl
@@ -179,13 +179,13 @@ points(sp::SinSpace,n)=points(domain(sp),2n+2)[2:n+1]
 for (Typ,Pltr!,Pltr) in ((:TransformPlan,:plan_transform!,:plan_transform),
                          (:ITransformPlan,:plan_itransform!,:plan_itransform))
     @eval begin
-        $Pltr!{T<:FFTW.fftwNumber}(sp::SinSpace,x::Vector{T}) =
+        $Pltr!{DD,T<:FFTW.fftwNumber}(sp::SinSpace{DD},x::Vector{T}) =
             $Typ(sp,FFTW.plan_r2r!(x,FFTW.RODFT00),Val{true})
-        $Pltr{T<:FFTW.fftwNumber}(sp::SinSpace,x::Vector{T}) =
+        $Pltr{DD,T<:FFTW.fftwNumber}(sp::SinSpace{DD},x::Vector{T}) =
             $Typ(sp,$Pltr!(sp,x),Val{false})
-        $Pltr!{T}(sp::SinSpace,x::Vector{T}) =
+        $Pltr!{DD,T}(sp::SinSpace{DD},x::Vector{T}) =
             error("transform for SinSpace only implemented for fftwNumbers")
-        $Pltr{T}(sp::SinSpace,x::Vector{T}) =
+        $Pltr{DD,T}(sp::SinSpace{DD},x::Vector{T}) =
             error("transform for SinSpace only implemented for fftwNumbers")
 
         *{T,D}(P::$Typ{T,SinSpace{D},false},vals::Vector{T}) = P.plan*copy(vals)

--- a/src/Spaces/Hermite/hermitetransform.jl
+++ b/src/Spaces/Hermite/hermitetransform.jl
@@ -1,12 +1,16 @@
 points(H::Hermite,n)=gausshermite(n)[1]
 
-plan_transform(H::Hermite,v::Vector) = gausshermite(length(v))
-plan_itransform(H::Hermite,cfs::Vector) = points(H,length(cfs))
-function transform(H::Hermite,vals,plan::Tuple{Vector,Vector})
-    x,w = plan
+plan_transform(H::Hermite,v::Vector) = TransformPlan(H,gausshermite(length(v)),Val{false})
+plan_itransform(H::Hermite,cfs::Vector) = ITransformPlan(H,points(H,length(cfs)),Val{false})
+
+
+
+function *{T,HH<:Hermite}(P::TransformPlan{T,HH,false},vals::AbstractVector)
+    x,w = P.plan
     V=hermitep(0:length(vals)-1,x)'
     nrm=(V.^2)*w
-
     V*(w.*vals)./nrm
 end
-itransform(H::Hermite,cfs,plan::Vector) = hermitep(0:length(cfs)-1,tocanonical(H,plan))*cfs
+
+*{T,HH<:Hermite}(P::ITransformPlan{T,HH,false},cfs::AbstractVector) =
+    hermitep(0:length(cfs)-1,tocanonical(H,P.plan))*cfs

--- a/src/Spaces/Jacobi/jacobitransform.jl
+++ b/src/Spaces/Jacobi/jacobitransform.jl
@@ -8,11 +8,13 @@ immutable JacobiTransformPlan{DD,T,TT}
 end
 
 plan_transform(S::Jacobi,v::Vector) = JacobiTransformPlan(S,gaussjacobi(length(v),S.a,S.b)...)
-function transform(S::Jacobi,vals,plan::JacobiTransformPlan)
+function *(plan::JacobiTransformPlan,vals)
 #    @assert S==plan.space
+    S = plan.space
     x,w = plan.points, plan.weights
     V=jacobip(0:length(vals)-1,S.a,S.b,x)'
-    w2=w.*(1-x).^(S.a-plan.space.a).*(1+x).^(S.b-plan.space.b)   # need to weight if plan is different
+#    w2=w.*(1-x).^(S.a-plan.space.a).*(1+x).^(S.b-plan.space.b)   # need to weight if plan is different
+    w2=w
     nrm=(V.^2)*w2
 
     V*(w2.*vals)./nrm
@@ -28,10 +30,9 @@ end
 
 
 plan_itransform(S::Jacobi,cfs::Vector) = JacobiITransformPlan(S,points(S,length(cfs)))
-function itransform(S::Jacobi,cfs,plan::JacobiITransformPlan)
-#    @assert S==plan.space
-    jacobip(0:length(cfs)-1,S.a,S.b,tocanonical(S,plan.points))*cfs
-end
+*(P::JacobiITransformPlan,cfs) =
+    jacobip(0:length(cfs)-1,P.space.a,P.space.b,tocanonical(P.space,P.points))*cfs
+
 
 function coefficients(f::Vector,a::Jacobi,b::Chebyshev)
     if domain(a) == domain(b) && (!isapproxinteger(a.a-0.5) || !isapproxinteger(a.b-0.5))

--- a/src/Spaces/Laguerre/Laguerre.jl
+++ b/src/Spaces/Laguerre/Laguerre.jl
@@ -94,11 +94,12 @@ immutable LaguerreTransformPlan{T,TT}
 end
 
 plan_transform(S::Laguerre,v::Vector) = LaguerreTransformPlan(S,gausslaguerre(length(v),1.0S.α)...)
-function transform(S::Laguerre,vals,plan::LaguerreTransformPlan)
+function *(plan::LaguerreTransformPlan,vals)
 #    @assert S==plan.space
     x,w = plan.points, plan.weights
-    V=laguerrel(0:length(vals)-1,S.α,x)'
-    w2=w.*x.^(S.α-plan.space.α)   # need to weight if plan is different
+    V=laguerrel(0:length(vals)-1,plan.space.α,x)'
+    #w2=w.*x.^(S.α-plan.space.α)   # need to weight if plan is different
+    w2=w
     nrm=(V.^2)*w2
     V*(w2.*vals)./nrm
 end

--- a/src/Spaces/Modifier/ArraySpace.jl
+++ b/src/Spaces/Modifier/ArraySpace.jl
@@ -77,7 +77,7 @@ function transform{SS,T,V<:Number}(AS::ArraySpace{SS,1,T},M::Array{V,2})
 
     @assert size(M,2)==n
     plan = plan_transform(AS.space,M[:,1])
-    cfs=Vector{V}[transform(AS.space,M[:,k],plan)  for k=1:size(M,2)]
+    cfs=Vector{V}[plan*M[:,k]  for k=1:size(M,2)]
 
     interlace(cfs,AS)
 end

--- a/src/Spaces/Modifier/SumSpace.jl
+++ b/src/Spaces/Modifier/SumSpace.jl
@@ -489,7 +489,16 @@ function points(d::PiecewiseSpace,n)
         vcat([points(d.spaces[j],k) for j=r+1:length(d)]...)]
 end
 
-function transform(S::PiecewiseSpace,vals::Vector,plan...)
+plan_transform(sp::PiecewiseSpace,vals::Vector) =
+    TransformPlan{eltype(vals),typeof(sp),false,Void}(sp,nothing)
+
+plan_itransform(sp::PiecewiseSpace,vals::Vector) =
+    ITransformPlan{eltype(vals),typeof(sp),false,Void}(sp,nothing)
+
+
+
+function *{PS<:PiecewiseSpace,T}(P::TransformPlan{T,PS,false},vals::Vector{T})
+    S=P.space
     n=length(vals)
     K=length(S)
     k=div(n,K)
@@ -514,21 +523,21 @@ function transform(S::PiecewiseSpace,vals::Vector,plan...)
     interlace(M,S)
 end
 
-itransform(S::PiecewiseSpace,cfs::Vector,plan...) =
-    vcat([itransform(S.spaces[j],Fun(S,cfs)[j].coefficients) for j=1:length(S)]...)
+*{T,PS<:PiecewiseSpace}(P::ITransformPlan{T,PS,false},cfs::Vector{T}) =
+    vcat([itransform(P.space.spaces[j],Fun(P.space,cfs)[j].coefficients) for j=1:length(P.space)]...)
 
 
 
-
-itransform(S::SumSpace,cfs,plan...) = Fun(S,cfs)(points(S,length(cfs)))
-itransform!(S::SumSpace,cfs,plan...) = (cfs[:]=Fun(S,cfs)(points(S,length(cfs))))
+itransform(S::SumSpace,cfs) = Fun(S,cfs)(points(S,length(cfs)))
+itransform!(S::SumSpace,cfs) = (cfs[:]=Fun(S,cfs)(points(S,length(cfs))))
 
 
 
 ## SumSpace{ConstantSpace}
 # this space is special
 
-union_rule(P::PiecewiseSpace,C::ConstantSpace{AnyDomain})=PiecewiseSpace(map(sp->union(sp,C),P.spaces))
+union_rule(P::PiecewiseSpace,C::ConstantSpace{AnyDomain}) =
+    PiecewiseSpace(map(sp->union(sp,C),P.spaces))
 
 
 

--- a/src/Spaces/Singularities/Singularities.jl
+++ b/src/Spaces/Singularities/Singularities.jl
@@ -18,19 +18,31 @@ immutable WeightSpacePlan{S,P,T,V}
     weights::Vector{V}
 end
 
-
-for TYP in (:plan_transform,:plan_itransform)
-    @eval function $TYP(S::WeightSpace,vals::Vector)
-        pts=points(S,length(vals))
-        WeightSpacePlan(S,$TYP(S.space,vals),pts,weight(S,pts))
-    end
+immutable IWeightSpacePlan{S,P,T,V}
+    space::S
+    plan::P
+    points::Vector{T}
+    weights::Vector{V}
 end
 
+function plan_transform(S::WeightSpace,vals::Vector)
+    pts=points(S,length(vals))
+    WeightSpacePlan(S,plan_transform(S.space,vals),pts,weight(S,pts))
+end
 
-transform(sp::WeightSpace,vals::Vector,plan::WeightSpacePlan) =
-    transform(sp.space,vals./(sp==plan.space?plan.weights:weight(sp,plan.points)),plan.plan)
-itransform(sp::WeightSpace,cfs::Vector,plan::WeightSpacePlan) =
-    itransform(sp.space,cfs,plan.plan).*(sp==plan.space?plan.weights:weight(sp,plan.points))
+function plan_itransform(S::WeightSpace,vals::Vector)
+    pts=points(S,length(vals))
+    IWeightSpacePlan(S,plan_itransform(S.space,vals),pts,weight(S,pts))
+end
+
+*(P::WeightSpacePlan,vals::Vector) = P.plan*(vals./P.weights)
+*(P::IWeightSpacePlan,cfs::Vector) = P.weights.*(P.plan*cfs)
+
+
+# transform(sp::WeightSpace,vals::Vector,plan::WeightSpacePlan) =
+#     transform(sp.space,vals./(sp==plan.space?plan.weights:weight(sp,plan.points)),plan.plan)
+# itransform(sp::WeightSpace,cfs::Vector,plan::WeightSpacePlan) =
+#     itransform(sp.space,cfs,plan.plan).*(sp==plan.space?plan.weights:weight(sp,plan.points))
 
 
 

--- a/src/Spaces/Ultraspherical/ContinuousSpace.jl
+++ b/src/Spaces/Ultraspherical/ContinuousSpace.jl
@@ -14,9 +14,11 @@ spacescompatible(a::ContinuousSpace,b::ContinuousSpace) = domainscompatible(a,b)
 conversion_rule{CD<:Tuple{Vararg{ChebyshevDirichlet{1,1}}}}(a::ContinuousSpace,
                                                             b::PiecewiseSpace{CD,RealBasis}) = a
 
-plan_transform(S::ContinuousSpace,vals::Vector) = identity  # TODO: implement plan
+plan_transform(sp::ContinuousSpace,vals::Vector) =
+    TransformPlan{eltype(vals),typeof(sp),false,Void}(sp,nothing)
 
-function transform(S::ContinuousSpace,vals::Vector,plan...)
+function *{T,SS<:ContinuousSpace}(P::TransformPlan{T,SS,false},vals::Vector{T})
+    S = P.space
     n=length(vals)
     d=domain(S)
     K=numpieces(d)

--- a/src/Spaces/Ultraspherical/Ultraspherical.jl
+++ b/src/Spaces/Ultraspherical/Ultraspherical.jl
@@ -52,8 +52,8 @@ end
 
 function UltrasphericalPlan(λ::Number,vals)
     if λ == 0.5
-        cp=plan_transform(Chebyshev(),vals)
-        c2lp=FastTransforms.th_cheb2legplan(eltype(vals),length(vals))
+        cp = plan_transform(Chebyshev(),vals)
+        c2lp = FastTransforms.th_cheb2legplan(eltype(vals),length(vals))
         UltrasphericalPlan{typeof(cp),typeof(c2lp)}(cp,c2lp)
     else
         error("Not implemented")
@@ -71,18 +71,15 @@ function UltrasphericalIPlan(λ::Number,cfs)
 end
 
 *(UP::UltrasphericalPlan,v::AbstractVector) =
-    UP.cheb2legplan*transform(Chebyshev(),v,UP.chebplan)
+    UP.cheb2legplan*(UP.chebplan*v)
 *(UP::UltrasphericalIPlan,v::AbstractVector) =
-    itransform(Chebyshev(),UP.leg2chebplan*v,UP.chebiplan)
+    UP.chebiplan*(UP.leg2chebplan*v)
 
 
-plan_transform(S::Ultraspherical{Int},vals::Vector) = plan_transform(canonicalspace(S),vals)
+plan_transform(sp::Ultraspherical{Int},vals::Vector) = CanonicalTransformPlan(sp,vals)
 plan_transform(S::Ultraspherical,vals::Vector) = UltrasphericalPlan(order(S),vals)
-plan_itransform(S::Ultraspherical{Int},cfs::Vector) = plan_itransform(canonicalspace(S),cfs)
+plan_itransform(S::Ultraspherical{Int},cfs::Vector) = ICanonicalTransformPlan(sp,vals)
 plan_itransform(S::Ultraspherical,cfs::Vector) = UltrasphericalIPlan(order(S),cfs)
-
-transform(S::Ultraspherical,vals,pl::UltrasphericalPlan) = pl*vals
-itransform(S::Ultraspherical,cfs,pl::UltrasphericalIPlan) = pl*cfs
 
 ## Construction
 

--- a/src/Spaces/Ultraspherical/Ultraspherical.jl
+++ b/src/Spaces/Ultraspherical/Ultraspherical.jl
@@ -77,9 +77,9 @@ end
 
 
 plan_transform(sp::Ultraspherical{Int},vals::Vector) = CanonicalTransformPlan(sp,vals)
-plan_transform(S::Ultraspherical,vals::Vector) = UltrasphericalPlan(order(S),vals)
-plan_itransform(S::Ultraspherical{Int},cfs::Vector) = ICanonicalTransformPlan(sp,vals)
-plan_itransform(S::Ultraspherical,cfs::Vector) = UltrasphericalIPlan(order(S),cfs)
+plan_transform(sp::Ultraspherical,vals::Vector) = UltrasphericalPlan(order(sp),vals)
+plan_itransform(sp::Ultraspherical{Int},cfs::Vector) = ICanonicalTransformPlan(sp,cfs)
+plan_itransform(sp::Ultraspherical,cfs::Vector) = UltrasphericalIPlan(order(sp),cfs)
 
 ## Construction
 

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -11,10 +11,10 @@ function testtransforms(S::Space;minpoints=1,invertibletransform=true)
     # transform tests
     v = rand(max(minpoints,min(100,ApproxFun.dimension(S))))
     plan = plan_transform(S,v)
-    @test transform(S,v)  == transform(S,v,plan)
+    @test transform(S,v)  == plan*v
 
     iplan = plan_itransform(S,v)
-    @test itransform(S,v)  == itransform(S,v,iplan)
+    @test itransform(S,v)  == iplan*v
 
     if invertibletransform
         for k=max(1,minpoints):min(5,dimension(S))

--- a/test/FourierTest.jl
+++ b/test/FourierTest.jl
@@ -17,12 +17,13 @@ end
 
 
 f=Fun(t->cos(t)+cos(3t),CosSpace)
-
+@test_approx_eq f(0.1) cos(0.1)+cos(3*0.1)
 @test (f.*f-Fun(t->(cos(t)+cos(3t))^2,CosSpace)).coefficients|>norm <100eps()
 
 
 
 f=Fun(exp,Taylor(Circle()))
+@test_approx_eq f(exp(0.1im)) exp(exp(0.1im))
 g=Fun(z->1./(z-.1),Hardy{false}(Circle()))
 @test_approx_eq (f(1.)+g(1.)) (exp(1.) + 1./(1-.1))
 
@@ -42,9 +43,9 @@ z=Fun(Fourier(Γ))
 
 
 
-@test_approx_eq Fun(Laurent(0..2π),[1,1.,1.])(0.1) 1+2cos(0.1+π)
-@test_approx_eq Fun(Laurent(-1..1),[1,1.,1.])(0.1) 1+2cos(π*0.1)
-@test_approx_eq Fun(Laurent(0..1),[1,1.,1.])(0.1) 1+2cos(2π*(0.1-1/2))
+@test_approx_eq Fun(Laurent(0..2π),[1,1.,1.])(0.1) 1+2cos(0.1)
+@test_approx_eq Fun(Laurent(-1..1),[1,1.,1.])(0.1) 1+2cos(π*(0.1+1))
+@test_approx_eq Fun(Laurent(0..1),[1,1.,1.])(0.1) 1+2cos(2π*0.1)
 
 
 @test abs(Fun(cos,Circle())(exp(0.1im))-cos(exp(0.1im)))<100eps()

--- a/test/FullPDETest.jl
+++ b/test/FullPDETest.jl
@@ -416,7 +416,7 @@ u=linsolve(A,F;tolerance=1E-10)
 println("    Periodic x Interval tests")
 
 
-dθ=PeriodicInterval();dt=Interval(0,1.)
+dθ=PeriodicInterval(-π,π);dt=Interval(0,1.)
 d=dθ*dt
 ε=0.1
 Dθ=Derivative(d,[1,0]);Dt=Derivative(d,[0,1])
@@ -430,6 +430,7 @@ dθ=PeriodicInterval(-2.,2.);dt=Interval(0,1.)
 d=dθ*dt
 Dθ=Derivative(d,[1,0]);Dt=Derivative(d,[0,1])
 u0=Fun(θ->exp(-20θ^2),dθ)
+
 A=Dt+Dθ
 
 testbandedblockbandedoperator(A)
@@ -468,7 +469,7 @@ u=linsolve([timedirichlet(d);Dt-ε*Dx^2-V*Dx],[f;zeros(3)];tolerance=1E-7)
 
 println("    Periodic tests")
 
-d=PeriodicInterval()^2
+d=PeriodicInterval(-π,π)^2
 f=Fun((θ,ϕ)->exp(-10(sin(θ/2)^2+sin(ϕ/2)^2)),d)
 A=Laplacian(d)+.1I
 @time u=A\f

--- a/test/OperatorTest.jl
+++ b/test/OperatorTest.jl
@@ -208,7 +208,7 @@ testbandedoperator(ApproxFun.ReverseOrientation(Chebyshev()))
 
 
 @test norm(ApproxFun.Reverse(Fourier())*Fun(t->cos(cos(t-0.2)-0.1),Fourier()) - Fun(t->cos(cos(-t-0.2)-0.1),Fourier())) < 10eps()
-@test norm(ApproxFun.ReverseOrientation(Fourier())*Fun(t->cos(cos(t-0.2)-0.1),Fourier()) - Fun(t->cos(cos(t-0.2)-0.1),Fourier(PeriodicInterval(π,-π)))) < 10eps()
+@test norm(ApproxFun.ReverseOrientation(Fourier())*Fun(t->cos(cos(t-0.2)-0.1),Fourier()) - Fun(t->cos(cos(t-0.2)-0.1),Fourier(PeriodicInterval(2π,0)))) < 10eps()
 
 
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -153,7 +153,7 @@ o=ones(Γ)
 @test_approx_eq o(0.4) 1.0
 
 G=Fun(z->in(z,Γ[2])?[1 0; -1/z 1]:[z 0; 0 1/z],Γ)
-@test_approx_eq (G-I)(1.) (G(1.)-I)
+@test_approx_eq (G-I)(exp(0.1im)) (G(exp(0.1im))-I)
 
 
 ## Previoius seffdault

--- a/test/VectorTest.jl
+++ b/test/VectorTest.jl
@@ -17,14 +17,14 @@ f=Fun(x->[exp(x),cos(x)],d)
 
 b=Any[0.,0.,f...]
 f1,f2=vec(f)
-u=A\b
+@time u=A\b
 u1=vec(u)[1];u2=vec(u)[2];
 
 @test norm(u1'-u1+2u2-f1)<10eps()
 @test norm(u2'+u2-f2)<10eps()
 
 Ai=Operator(A)
-u=Ai\b
+@time u=Ai\b
 u1=vec(u)[1];u2=vec(u)[2];
 
 @test norm(u1'-u1+2u2-f1)<10eps()
@@ -44,7 +44,7 @@ A=[B 0;
 b=Any[0.,0.,0.,f...]
 
 
-u=A\b
+@time u=A\b
 u1=vec(u)[1];u2=vec(u)[2];
 
 
@@ -52,7 +52,7 @@ u1=vec(u)[1];u2=vec(u)[2];
 @test norm(u2'+u2-f2)<2eps()
 
 Ai=Operator(A)
-u=Ai\b
+@time u=Ai\b
 u1=vec(u)[1];u2=vec(u)[2];
 
 
@@ -72,7 +72,7 @@ B=Evaluation(d,0.)
 D=Derivative(d)
 A=rand(n,n)
 L=[B;D-A]
-u=L\eye(2n,n)
+@time u=L\eye(2n,n)
 @test norm(evaluate(u,1.)-expm(A))<eps(1000.)
 
 
@@ -82,7 +82,7 @@ B=Evaluation(d,0.)
 D=Derivative(d)
 A=rand(n,n)
 L=[B;D-A]
-u=L\eye(2n,2)
+@time u=L\eye(2n,2)
 @test norm(evaluate(u,1.)-expm(A)[:,1:2])<eps(1000.)
 
 
@@ -165,9 +165,7 @@ F=Fun((G-I)[:,1])
 @test F==Fun(vec(F),space(F))
 
 @test_approx_eq inv(G(exp(0.1im))) inv(G)(exp(0.1im))
-
 @test_approx_eq Fun(eye(2),space(G))(exp(0.1im)) eye(2)
-
 @test_approx_eq Fun(I,space(G))(exp(0.1im)) eye(2)
 
 
@@ -176,7 +174,6 @@ F=Fun((G-I)[:,1])
 f=Fun(t->[cos(t) 0;sin(t) 1],-π..π)
 g=Fun(f,Space(PeriodicInterval(-π,π)))
 @test_approx_eq g(.1) f(.1)
-
 
 
 

--- a/test/fulltests.jl
+++ b/test/fulltests.jl
@@ -144,7 +144,8 @@ M=Multiplication(f,sp2)
 ## Legendre conversions
 testspace(Ultraspherical(1);haslineintegral=false)
 testspace(Ultraspherical(2);haslineintegral=false)
-@time testspace(Ultraspherical(1//2);haslineintegral=false,minpoints=2)  # minpoints is a tempory fix a bug
+# minpoints is a tempory fix a bug
+@time testspace(Ultraspherical(1//2);haslineintegral=false,minpoints=2)
 
 @test norm(Fun(exp,Ultraspherical(1//2))-Fun(exp,Jacobi(0,0))) < 100eps()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ println("Domain tests")
 @test !in(0.45-0.65im,Interval())
 @test cumsum(ApproxFun.Flatten(([3],ApproxFun.repeated(2)))).it[2]==ApproxFun.Count(5,2)
 @test reverse(Arc(1,2,(0.1,0.2))) == Arc(1,2,(0.2,0.1))
+@test in(0.1,PeriodicInterval(2π,0))
 
 @time include("MatrixTest.jl")
 


### PR DESCRIPTION

This will reverse the order of Chebyshev points, reorders Fourier and updates the usage of planned transforms to be `P*vals` instead of `transform(S,vals,plan)`, to be consistent with `plan_fft`.

This also will fix the thread safety issues of `ichebyshevtransform`.

