### PR TITLE
Fix example equation

### DIFF
--- a/docs/src/usage/equations.md
+++ b/docs/src/usage/equations.md
@@ -92,7 +92,7 @@ functionals.  For example, we can solve the system
 
 $$\begin{align*}
     u'' - u + 2v &= {\rm e}^x  \cr
-    v' + v &= {\rm e}^x  \cr
+    v' + v &= cos(x) \cr
     u(-1) &= u'(-1) = v(-1) = 0
 \end{align*}$$
 


### PR DESCRIPTION
In the example it had e^x, but in the code it had cos(x). So I changed the example to match the code.