### PR TITLE
Broadcasting 0.6

### DIFF
--- a/src/Domains/UnionDomain.jl
+++ b/src/Domains/UnionDomain.jl
@@ -47,6 +47,10 @@ Base.union(d1::EmptyDomain,d2::EmptyDomain) = d1
 Base.union(d1::EmptyDomain,d2::Domain) = d2
 Base.union(d1::Domain,d2::EmptyDomain) = d1
 
+Base.union(d1::AnyDomain,d2::AnyDomain) = d1
+Base.union(d1::AnyDomain,d2::Domain) = d2
+Base.union(d1::Domain,d2::AnyDomain) = d1
+
 function Base.union(d1::Domain,d2::Domain)
     if d1==d2
         return d1

--- a/src/Fun/Fun.jl
+++ b/src/Fun/Fun.jl
@@ -493,6 +493,20 @@ end
 
 ## broadcasting
 
+
+Base.Broadcast._containertype(::Type{<:Fun}) = Fun
+
+Base.Broadcast.promote_containertype(::Type{Fun}, ::Type{Fun}) = Fun
+Base.Broadcast.promote_containertype(::Type{Array}, ::Type{Fun}) = Array
+Base.Broadcast.promote_containertype(::Type{Fun}, ::Type{Array}) = Array
+Base.Broadcast.promote_containertype(::Type{Fun}, ct) = Fun
+Base.Broadcast.promote_containertype(ct, ::Type{Fun}) = Fun
+
+
+
+
+Base.Broadcast.broadcast_c(op,
+
 broadcast(op,f::Fun) = Fun(x -> op(f(x)), domain(f))
 broadcast(op,f::Fun,c::Number) = Fun(x -> op(f(x),c), domain(f))
 broadcast(op,c::Number,f::Fun) = Fun(x -> op(c,f(x)), domain(f))

--- a/src/Fun/Space.jl
+++ b/src/Fun/Space.jl
@@ -55,9 +55,6 @@ Base.endof(s::Space) = 1
 #supports broadcasting, overloaded for ArraySpace
 Base.size(::Space) = ()
 
-# but broadcasts like Number (even for overloaded ArraySpace)
-# TODO for v0.6: remove this
-Base.broadcast(f,x::Union{Number,Domain,Space}...) = f(x...)
 
 # the default is all spaces have one-coefficient blocks
 blocklengths(S::Space) = repeated(true,dimension(S))

--- a/src/Spaces/Modifier/ArraySpace.jl
+++ b/src/Spaces/Modifier/ArraySpace.jl
@@ -103,6 +103,9 @@ Base.getindex(f::Fun{DSS},k::Integer) where {DSS<:ArraySpace} = component(f,k)
 Base.getindex{S,DD,RR}(f::Fun{MatrixSpace{S,DD,RR}},k::Integer,j::Integer) =
     f[k+stride(f,2)*(j-1)]
 
+Base.getindex(f::Fun{DSS},kj::CartesianIndex{1}) where {DSS<:ArraySpace} = f[kj[1]]
+Base.getindex(f::Fun{DSS},kj::CartesianIndex{2}) where {DSS<:ArraySpace} = f[kj[1],kj[2]]
+
 
 function Fun{S,V,VV,DD,RR}(A::AbstractArray{Fun{VectorSpace{S,DD,RR},V,VV},2})
     @assert size(A,1)==1

--- a/test/broadcastingtest.jl
+++ b/test/broadcastingtest.jl
@@ -5,16 +5,37 @@ using ApproxFun, Base.Test
 ## broadcast
 
 f=Fun(exp)
-@test norm(exp.(f) - exp(f)) < 100eps()
-@test norm(besselj.(1,f)-besselj(1,f)) < 3000eps()
+
+@test exp.(f) ≈ exp(f)
+@test besselj.(1,f) ≈ besselj(1,f)
 @test atan2.(f,1)(0.1) ≈ atan2(f(0.1),1)
 @test atan2.(f,f)(0.1) ≈ atan2(f(0.1),f(0.1))
 
+# test triplet with mixed scalar-fun
+@test ((a,b,c) -> exp(a +b+c)).(f,2.0,f) ≈ exp(2f + 2.0)
 
 x = Fun()
-@test ≈(exp(x),exp.(x);atol=10eps())
+@test exp(x) ≈ exp.(x) atol=10eps()
 
-f= Fun()
+
+# Array test
+@test exp.( x .+ [1,2,3]) isa Vector
+@test exp.(x .+ [1,2]) ≈ [exp(x+1),exp(x+2)]
+
+@test exp.( x .+ [x;x]) isa Fun
+@test exp.( x .+ [x;x]) ≈ [exp(2x);exp(2x)]
+
+@test exp.([x,x] .+ 2 .+ [x;x]) isa Vector
+@test exp.( [x,x] .+ 2 .+ [x;x]) ≈ [exp(2x+2),exp(2x+2)]
+
+
+# since array broadcasting takes presidence, the following
+# does not try to call a constructor:
+@test ApproxFun.tocanonical.(x,[0.1,0.2]) ≈ [0.1,0.2]
+
+
+# broadcast! tests
+f = Fun()
 f .= exp.(x)
 @test ≈(exp(x),f;atol=10eps())
 


### PR DESCRIPTION
This interacts with 0.6 broadcasting machinery to allow broadcasting over arbitrary number of arguments. 

It also clarifies a previous ambiguity: if `Array`s are involved, classical broadcasting works as expected, and scalar Fun's are treated like scalars. 