### PR TITLE
Add QuotientSpace

### DIFF
--- a/src/Extras/show.jl
+++ b/src/Extras/show.jl
@@ -112,6 +112,11 @@ function Base.show(io::IO,s::LogWeight)
     print(io,"]")
 end
 
+function Base.show(io::IO,s::QuotientSpace)
+    show(io,s.space)
+    print(io," /\n")
+    show(io,s.bcs;header=false)
+end
 
 
 function Base.show(io::IO,ss::SumSpace)

--- a/src/Spaces/Modifier/Modifier.jl
+++ b/src/Spaces/Modifier/Modifier.jl
@@ -3,6 +3,7 @@ include("SumSpace.jl")
 include("ArraySpace.jl")
 include("ProductSpaceOperators.jl")
 include("SubSpace.jl")
+include("QuotientSpace.jl")
 
 
 ⊕(A::Space,B::Space) = domainscompatible(A,B) ? SumSpace(A,B) : PiecewiseSpace(A,B)

--- a/src/Spaces/Modifier/QuotientSpace.jl
+++ b/src/Spaces/Modifier/QuotientSpace.jl
@@ -1,0 +1,145 @@
+import Base.BLAS.@blasfunc
+import Base.LinAlg: chkstride1, BlasInt
+import Base.LinAlg.LAPACK.chklapackerror
+
+export QuotientSpace
+
+struct QuotientSpace{S,O<:Operator,DD,T,RT} <: Space{DD,T}
+    space::S
+    bcs::O
+    A::Matrix{T}
+    x::Vector{T}
+    b::Vector{T}
+    U::Matrix{T}
+    Σ::Diagonal{T}
+    VT::Matrix{T}
+    work::Vector{T}
+    iwork::Vector{Int}
+    rwork::Vector{RT}
+    info::Ref{BlasInt}
+    function QuotientSpace{S,O,DD,T,RT}(space::S, bcs::O) where {S,O,DD,T,RT}
+        n = size(bcs, 1)
+        @assert isfinite(n)
+        A = zeros(T, n, n)
+        x = zeros(T, n)
+        b = zeros(T, n)
+        U = zeros(T, n, n)
+        Σ = Diagonal(zeros(T, n))
+        VT = zeros(T, n, n)
+        work = Vector{T}(max((3n+7)*n,68))
+        iwork = Vector{Int}(8*n)
+        rwork = Vector{RT}((5*n+7)*n)
+        info = Ref{BlasInt}()
+        new{S,O,DD,T,RT}(space, bcs, A, x, b, U, Σ, VT, work, iwork, rwork, info)
+    end
+end
+
+QuotientSpace(sp::Space, bcs::Operator) = QuotientSpace{typeof(sp), typeof(bcs), domaintype(sp), rangetype(sp), real(rangetype(sp))}(sp, bcs)
+
+QuotientSpace(bcs::Operator) = QuotientSpace(domainspace(bcs), bcs)
+
+domain(QS::QuotientSpace) = domain(QS.space)
+dimension(QS::QuotientSpace) = dimension(QS.space)
+
+Conversion{SP<:Space}(Q::QuotientSpace{SP}, S::SP) = ConcreteConversion(Q, S)
+
+bandinds{SP,O,DD,T,RT}(C::ConcreteConversion{QuotientSpace{SP,O,DD,T,RT},SP}) = 0, size(C.domainspace.A, 1)
+
+function getindex{SP,O,DD,T,RT}(C::ConcreteConversion{QuotientSpace{SP,O,DD,T,RT},SP}, i::Integer, j::Integer)
+    sp = domainspace(C)
+    n = size(sp.A, 1)
+    A = sp.A
+    x = sp.x
+    b = sp.b
+    B = sp.bcs
+    U = sp.U
+    Σ = sp.Σ
+    VT = sp.VT
+    work = sp.work
+    iwork = sp.iwork
+    rwork = sp.rwork
+    info = sp.info
+
+    if i == j
+        one(T)
+    elseif i ≤ n && j ≤ n
+        zero(T)
+    elseif j-n ≤ i < j
+        for jj = 1:n, ii = 1:n
+            A[ii,jj] = B[ii,j+jj-n-1]
+        end
+        for ii = 1:n
+            b[ii] = -B[ii,j]
+        end
+        in_place_gesdd!(A, U, Σ.diag, VT, work, iwork, rwork, info)
+        At_mul_B!(x, U, b)
+        A_mul_B!(b, pinv!(Σ), x)
+        At_mul_B!(x, VT, b)
+        x[i+n-j+1]
+    else
+        zero(T)
+    end
+end
+
+function pinv!(D::Diagonal{T}) where T
+    d = D.diag
+    @inbounds @simd for i = 1:length(d)
+        isfinite(inv(d[i])) ? d[i]=inv(d[i]) : d[i]=zero(T)
+    end
+    D
+end
+
+for (gesdd, elty, relty) in ((:dgesdd_,:Float64,:Float64),
+                      (:sgesdd_,:Float32,:Float32),
+                      (:zgesdd_,:Complex128,:Float64),
+                      (:cgesdd_,:Complex64,:Float32))
+    @eval begin
+        #    SUBROUTINE DGESDD( JOBZ, M, N, A, LDA, S, U, LDU, VT, LDVT, WORK,
+        #                   LWORK, IWORK, INFO )
+        #*     .. Scalar Arguments ..
+        #      CHARACTER          JOBZ
+        #      INTEGER            INFO, LDA, LDU, LDVT, LWORK, M, N
+        #*     ..
+        #*     .. Array Arguments ..
+        #      INTEGER            IWORK( * )
+        #      DOUBLE PRECISION   A( LDA, * ), S( * ), U( LDU, * ),
+        #                        VT( LDVT, * ), WORK( * )
+        function in_place_gesdd!(A::Matrix{$elty}, U::Matrix{$elty}, S::Vector{$elty}, VT::Matrix{$elty}, work::Vector{$elty}, iwork::Vector{BlasInt}, rwork::Vector{$relty}, info::Ref{BlasInt})
+            chkstride1(A)
+            m, n   = size(A)
+            minmn  = min(m, n)
+            job = 'A'
+            lwork  = BlasInt(-1)
+            cmplx  = $elty != $relty
+            for i = 1:2
+                if cmplx
+                    ccall((@blasfunc($gesdd), liblapack), Void,
+                          (Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
+                           Ptr{BlasInt}, Ptr{$relty}, Ptr{$elty}, Ptr{BlasInt},
+                           Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                           Ptr{$relty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                          &job, &m, &n, A, &max(1,stride(A,2)), S, U, &max(1,stride(U,2)), VT, &max(1,stride(VT,2)),
+                          work, &lwork, rwork, iwork, info)
+                else
+                    ccall((@blasfunc($gesdd), liblapack), Void,
+                          (Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
+                           Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
+                           Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                           Ptr{BlasInt}, Ptr{BlasInt}),
+                          &job, &m, &n, A, &max(1,stride(A,2)), S, U, &max(1,stride(U,2)), VT, &max(1,stride(VT,2)),
+                          work, &lwork, iwork, info)
+                end
+                chklapackerror(info[])
+                if i == 1
+                    # Work around issue with truncated Float32 representation of lwork in
+                    # sgesdd by using nextfloat. See
+                    # http://icl.cs.utk.edu/lapack-forum/viewtopic.php?f=13&t=4587&p=11036&hilit=sgesdd#p11036
+                    # and
+                    # https://github.com/scipy/scipy/issues/5401
+                    lwork = round(BlasInt, nextfloat(real(work[1])))
+                    #work = Vector{$elty}(lwork)
+                end
+            end
+        end
+    end
+end

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -257,12 +257,12 @@ x=Fun()
 
 ### QuotientSpace test
 
-import ApproxFun: InterlaceOperator, SpaceOperator
+import ApproxFun: SpaceOperator
 
 for (bcs,ret) in ((Dirichlet(Chebyshev()),[1 -1 0 0 0;1 1 0 0 0]),
                   (Neumann(Chebyshev()),[0 1 -4 0 0;0 1 4 0 0]),
-                  (InterlaceOperator([DefiniteIntegral(Chebyshev());SpaceOperator(BasisFunctional(2),Chebyshev(),ConstantSpace())]),[2 0 0 0 0;0 1 0 0 0]),
-                  (InterlaceOperator(bvp(Chebyshev(),4)),[1 -1 1 -1 0;0 1 -4 9 0;1 1 1 1 0;0 1 4 9 0]))
+                  ([DefiniteIntegral(Chebyshev());SpaceOperator(BasisFunctional(2),Chebyshev(),ConstantSpace())],[2 0 0 0 0;0 1 0 0 0]),
+                  (vcat(bvp(Chebyshev(),4)...),[1 -1 1 -1 0;0 1 -4 9 0;1 1 1 1 0;0 1 4 9 0]))
     QS = QuotientSpace(bcs)
     C = Conversion(QS, QS.space)
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -253,3 +253,18 @@ x=Fun()
 
 ## ChebyshevDirichlet Integral
 @test Integral(S,1)*Fun(S,[1.,2.,3.]) ≈ integrate(Fun(Fun(S,[1.,2.,3.]),Chebyshev()))
+
+
+### QuotientSpace test
+
+import ApproxFun: InterlaceOperator, SpaceOperator
+
+for (bcs,ret) in ((Dirichlet(Chebyshev()),[1 -1 0 0 0;1 1 0 0 0]),
+                  (Neumann(Chebyshev()),[0 1 -4 0 0;0 1 4 0 0]),
+                  (InterlaceOperator([DefiniteIntegral(Chebyshev());SpaceOperator(BasisFunctional(2),Chebyshev(),ConstantSpace())]),[2 0 0 0 0;0 1 0 0 0]),
+                  (InterlaceOperator(bvp(Chebyshev(),4)),[1 -1 1 -1 0;0 1 -4 9 0;1 1 1 1 0;0 1 4 9 0]))
+    QS = QuotientSpace(bcs)
+    C = Conversion(QS, QS.space)
+
+    norm((bcs*C)[1:size(bcs, 1),1:5] - ret) < 1000eps()
+end


### PR DESCRIPTION
This adds a new type of modified `Space`, called `QuotientSpace`. It is designed to create a new function space where as many of the new basis functions as possible satisfies the provided functionals or operator with finite-dimensional range.

Suppose you want to work with modified Chebyshev polynomials with zero mean:

```julia
julia> using ApproxFun

julia> bcs = ApproxFun.InterlaceOperator([DefiniteIntegral(Chebyshev());ApproxFun.SpaceOperator(BasisFunctional(2),Chebyshev(),ConstantSpace())])
InterlaceOperator:Chebyshev(【-1.0,1.0】)→ApproxFun.ArraySpace{ApproxFun.ConstantSpace{ApproxFun.AnyDomain,R} where R,1,ApproxFun.AnyDomain,Float64}(ApproxFun.ConstantSpace{ApproxFun.AnyDomain,R} where R[ConstantSpace, ConstantSpace])
 2.0  0.0  -0.666667  0.0  -0.133333  0.0  -0.0571429  0.0  -0.031746  0.0  ⋯
 0.0  1.0   0.0       0.0   0.0       0.0   0.0        0.0   0.0       0.0  ⋯

julia> QS = QuotientSpace(bcs)
Chebyshev(【-1.0,1.0】) /
 2.0  0.0  -0.666667  0.0  -0.133333  0.0  -0.0571429  0.0  -0.031746  0.0  ⋯
 0.0  1.0   0.0       0.0   0.0       0.0   0.0        0.0   0.0       0.0  ⋯

julia> C = Conversion(QS, QS.space)
ConcreteConversion:Chebyshev(【-1.0,1.0】) /
 2.0  0.0  -0.666667  0.0  -0.133333  0.0  -0.0571429  0.0  -0.031746  0.0  ⋯
 0.0  1.0   0.0       0.0   0.0       0.0   0.0        0.0   0.0       0.0  ⋯→Chebyshev(【-1.0,1.0】)
 1.0  0.0  0.333333                                                   
      1.0  0.0       0.0                                              
           1.0       0.0  -0.2                                        
                     1.0   0.0  0.0                                   
                           1.0  0.0  -0.428571                        
                                1.0   0.0       0.0                   
                                      1.0       0.0  -0.555556        
                                                1.0   0.0       0.0   
                                                      1.0       0.0  ⋱
                                                                1.0  ⋱
                                                                     ⋱

julia> bcs*C
TimesOperator:Chebyshev(【-1.0,1.0】) /
 2.0  0.0  -0.666667  0.0  -0.133333  0.0  -0.0571429  0.0  -0.031746  0.0  ⋯
 0.0  1.0   0.0       0.0   0.0       0.0   0.0        0.0   0.0       0.0  ⋯→ApproxFun.ArraySpace{ApproxFun.ConstantSpace{ApproxFun.AnyDomain,R} where R,1,ApproxFun.AnyDomain,Float64}(ApproxFun.ConstantSpace{ApproxFun.AnyDomain,R} where R[ConstantSpace, ConstantSpace])
 2.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋯
 0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋯

```
Now, every basis function in the quotient space has zero mean except the first two.