### PR TITLE
Replaced clenshaw macro with generated function

### DIFF
--- a/src/LinearAlgebra/clenshaw.jl
+++ b/src/LinearAlgebra/clenshaw.jl
@@ -1,4 +1,4 @@
-export clenshaw, @clenshaw
+export clenshaw
 
 
 ##
@@ -23,14 +23,20 @@ function ClenshawPlan{T}(::Type{T},sp,N::Int,n::Int)
     ClenshawPlan(sp,Array{T}(n),Array{T}(n),Array{T}(n),A,B,C)
 end
 
-macro clenshaw(x, c...)
-    bk1,bk2 = :(zero(t)),:(zero(t))
-    N = length(c)
+clenshaw(x,c) = clenshaw_halved(2*x, c)
+
+@generated function clenshaw_halved(x, c::StaticArrays.SVector{N,R}) where {N, R}
+    a, b = :(zero(R)), :(zero(R))
+    as = []
     for k = N:-1:2
-        bk2, bk1 = bk1, :(muladd(t,$bk1,$(esc(c[k]))-$bk2))
+        ak = Symbol("a",k)
+        push!(as, :($ak = $a))
+        a = :(muladd(x,$a,c[$k]-$b))
+        b = :($ak)
     end
-    ex = :(muladd(t/2,$bk1,$(esc(c[1]))-$bk2))
-    Expr(:block, :(t = $(esc(2))*$(esc(x))), ex)
+    Expr(:block,
+    as...,
+    :(muladd(x/2,$a,c[1]-$b)))
 end
 
 for TYP in (:AbstractVector,:AbstractMatrix)

--- a/test/ClenshawTest.jl
+++ b/test/ClenshawTest.jl
@@ -1,0 +1,5 @@
+using ApproxFun, StaticArrays, Base.Test
+
+test_function = Fun(sin, 50)
+
+@test test_function(0.9) ≈ clenshaw(0.9, SVector{50}(test_function.coefficients))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ println("Domain tests")
 
 
 println("Fun tests")
+@time include("ClenshawTest.jl")
 @time include("ChebyshevTest.jl")
 @time include("FourierTest.jl")
 @time include("ComplexTest.jl")


### PR DESCRIPTION
Based on [this discourse thread](https://discourse.julialang.org/t/evaluate-integral-on-many-points-cubature-jl/1723/45), I've replaced the `@clenshaw` macro with a generated function (to be able to pass a static vector of coefficients) that generates code more efficiently (linear and not exponential in the number of coefficient of the polynomial) and is faster than a normal function as it can "unroll the loop" at compile time.

Here is a quick benchmark:

```
julia> using ApproxFun, StaticArrays, BenchmarkTools

julia> test_function = Fun(sin, 50);

julia> @benchmark extrapolate($test_function, 0.9)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     164.904 ns (0.00% GC)
  median time:      180.905 ns (0.00% GC)
  mean time:        191.356 ns (0.00% GC)
  maximum time:     1.461 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     700

julia> @benchmark clenshaw(0.9, $(SVector{50}(test_function.coefficients)))
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     93.000 ns (0.00% GC)
  median time:      93.244 ns (0.00% GC)
  mean time:        95.124 ns (0.00% GC)
  maximum time:     603.777 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     952
```

