### PR TITLE
Fast evaluation of a LowRankFun on a cartesian grid x ⨂ y

### DIFF
--- a/src/Multivariate/LowRankFun.jl
+++ b/src/Multivariate/LowRankFun.jl
@@ -357,6 +357,18 @@ function evaluate(f::LowRankFun,::Colon,y::Number)
     Fun(first(f.A).space,ret)
 end
 
+"""
+    f.(x::AbstractVector, y':::AbstractMatrix)
+Fast evaluation of a LowRankFun on a cartesian grid x ⨂ y.
+"""
+function Base.broadcast(f::LowRankFun, x::AbstractVector, y::AbstractMatrix)
+    ret = zeros(length(y), length(x))
+    #println(InRed * "FROM BROADCAST" * InDefault)
+    for k = 1:rank(f)
+        ret +=  (f.A[k].(x) * f.B[k].(y))'
+    end
+    ret
+end
 
 ## Truncate
 #TODO: should reduce rank if needed

--- a/test/MultivariateTest.jl
+++ b/test/MultivariateTest.jl
@@ -73,8 +73,13 @@ f=Fun((x,y)->exp(x)*cos(y))
 
 @test G(.357,.246) ≈ besselj0(10(.246-.357))
 
-
-
+# test "fast" grid evaluation of LowRankFun
+f = LowRankFun((x,y) -> exp(x) * cos(y)); n = 1000
+x = linspace(-1, 1, n); y = linspace(-1, 1, n)
+X = ones(n) * linspace(-1, 1, n)'; Y = linspace(-1, 1, n) * ones(1, n)
+@time v1 = f.(X, Y);
+@time v2 = f.(collect(x), collect(y)');
+@test v1 ≈ v2
 
 
 ## 1D in 2D


### PR DESCRIPTION
Improvement suggested by @dlfivefifty  in the  [issue](https://github.com/JuliaApproximation/ApproxFun.jl/issues/437)
