### PR TITLE
Fix findmax: missing broadcast call.

### DIFF
--- a/src/Extras/roots.jl
+++ b/src/Extras/roots.jl
@@ -328,8 +328,8 @@ for op in (:(Base.findmax),:(Base.findmin))
         function $op(f::Fun{S,T}) where {S<:RealSpace,T<:Real}
             # the following avoids warning when differentiate(f)==0
             pts = extremal_args(f)
-            ext,ind = $op(f(pts))
-	        ext,pts[ind]
+            ext,ind = $op(f.(pts))
+	    ext,pts[ind]
         end
     end
 end

--- a/test/ExtrasTest.jl
+++ b/test/ExtrasTest.jl
@@ -85,3 +85,8 @@ g=sum(f,1)/sum(f)
 f = Fun(x -> exp(-x^2/2),-5..5)
 g = cumsum(f)
 @test g(ApproxFun.bisectioninv(g,0.5)) ≈ 0.5
+
+# check findmin, findmax
+f = Fun(x -> exp(0.25x) + sin(x) + 0.5cos(10x), -4..4)
+@test [findmax(f)...] ≈ [3.0531164509549584, 1.886754631165656]
+@test [findmin(f)...] ≈ [-0.825047261209411, -1.5741041425422948]


### PR DESCRIPTION
I think it should be `f.(pts)`, not `f(pts)`. It fails right now:

```
julia> findmax(u)
ERROR: MethodError: no method matching isless(::Array{Float64,1}, ::Int64)
Closest candidates are:
  isless(!Matched::PyCall.PyObject, ::Any) at /Users/kirill/.julia/v0.6/PyCall/src/pyoperators.jl:71
  isless(!Matched::ApproxFun.Infinity{Bool}, ::Number) at /Users/kirill/.julia/v0.6/ApproxFun/src/LinearAlgebra/helper.jl:517
  isless(!Matched::ApproxFun.Infinity{Bool}, ::Number) at /Users/kirill/.julia/v0.6/ApproxFun/src/LinearAlgebra/helper.jl:517
  ...
Stacktrace:
 [1] in(::Array{Float64,1}, ::ApproxFun.Segment{Float64}) at /Users/kirill/.julia/v0.6/ApproxFun/src/Fun/Domain.jl:113
 [2] evaluate(::Array{Float64,1}, ::ApproxFun.Chebyshev{ApproxFun.Segment{Float64},Float64}, ::Array{Float64,1}) at /Users/kirill/.julia/v0.6/ApproxFun/src/Spaces/PolynomialSpace.jl:19
 [3] findmax(::ApproxFun.Fun{ApproxFun.Chebyshev{ApproxFun.Segment{Float64},Float64},Float64,Array{Float64,1}}) at /Users/kirill/.julia/v0.6/ApproxFun/src/Extras/roots.jl:331
```