### PR TITLE
Add function to find jump discontinuities

### DIFF
--- a/src/ApproxFun.jl
+++ b/src/ApproxFun.jl
@@ -53,7 +53,7 @@ const Vec{d,T} = SVector{d,T}
 
 export pad!, pad, chop!, sample,
        complexroots, roots, svfft, isvfft,
-       reverseorientation
+       reverseorientation, jumplocations
 
 ##Testing
 export bisectioninv

--- a/src/Extras/specialfunctions.jl
+++ b/src/Extras/specialfunctions.jl
@@ -640,6 +640,34 @@ for OP in (:abs,:sign,:log,:angle)
     end
 end
 
+# Return the locations of jump discontinuities
+#
+# Non Piecewise Spaces are assumed to have no jumps.
+function jumplocations(f::Fun)
+    eltype(domain(f))[]
+end
+
+# Return the locations of jump discontinuities
+function jumplocations(f::Fun{S}) where{S<:PiecewiseSpace}
+    d = domain(f)
+
+    if ncomponents(d) < 2
+      return eltype(domain(f))[]
+    end
+
+    dtol=10eps(eltype(d))
+    ftol=10eps(eltype(f))
+
+    dc = components(d)
+    fc = components(f)
+
+    isjump = isapprox.(first.(dc[2:end]), last.(dc[1:end-1]), rtol=dtol) .&
+           .!isapprox.(first.(fc[2:end]), last.(fc[1:end-1]), rtol=ftol)
+
+    locs = last.(dc[1:end-1])
+    locs[isjump]
+end
+
 #
 # These formulæ, appearing in Eq. (2.5) of:
 #

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -317,6 +317,12 @@ g = Fun(x->cos(50x),Ultraspherical(1)) + δ
 @test angle(f)(0.1) ≈ angle(cos(50*0.1))
 @test angle(f)(2.0) ≈ 0
 
+x = Fun(Domain(0..1) ∪ Domain(2..3))
+@test length(jumplocations(sign(x))) == 0
+
+x = Fun(Chebyshev(-1..1))
+@test length(jumplocations(x)) == 0
+@test all(jumplocations(sign(x) + sign(x+0.2)) .≈ [-0.2, 0])
 
 
 ## ones for SumSpace


### PR DESCRIPTION
This function assumes that jump discontinuities can only happen in
piecewise spaces, i.e., between domain components.  To locate the jumps,
it checks to make sure that the domains are connected and that the
function is discontinuous.

This commit addresses issue #556.