### PR TITLE
Changed function sig of norm to avoid method ambiguity

### DIFF
--- a/src/Fun/Fun.jl
+++ b/src/Fun/Fun.jl
@@ -401,7 +401,7 @@ for (OP,SUM) in ((:(norm),:(sum)),(:linenorm,:linesum))
     @eval begin
         $OP(f::Fun) = $OP(f,2)
 
-        function $OP(f::Fun{S},p::Number) where S<:Space{D,R} where {D,R<:Number}
+        function $OP(f::Fun{S},p::Real) where S<:Space{D,R} where {D,R<:Number}
             if p < 1
                 return error("p should be 1 ≤ p ≤ ∞")
             elseif 1 ≤ p < Inf

--- a/test/ChebyshevTest.jl
+++ b/test/ChebyshevTest.jl
@@ -183,4 +183,10 @@ using ApproxFun, LinearAlgebra, Test
   let w = Fun(x -> 1e5/(x*x+1), 283.72074879785936 .. 335.0101119042838)
       @test w(domain(w).a) ≈ 1e5/(domain(w).a^2+1)
   end
+
+  # Test for supremum norm
+  x = Fun()
+  f = 1/(1 + 25*(x^2))
+  @test norm(f, Inf) ≈ 1.0
+  
 end


### PR DESCRIPTION
This updates one of the method signatures of norm to avoid a method ambiguity with norm(itr, p::Real) in LinearAlgebra.  Only affects norm(Fun, Inf)