### PR TITLE
Allow operator I to be defined on an unset space.

### DIFF
--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -621,7 +621,7 @@ zero(::Type{Operator{T}}) where {T<:Number} = ZeroOperator(T)
 zero(::Type{O}) where {O<:Operator} = ZeroOperator(eltype(O))
 
 
-
+Operator(L::UniformScaling) = ConstantOperator(L, UnsetSpace())
 Operator(L::UniformScaling, s::Space) = ConstantOperator(L, s)
 Operator(L::UniformScaling{Bool}, s::Space) = L.λ ? IdentityOperator(s) : ZeroOperator(s)
 Operator(L::UniformScaling, d::Domain) = Operator(L, Space(d))

--- a/test/OperatorTest.jl
+++ b/test/OperatorTest.jl
@@ -35,6 +35,8 @@ using ApproxFun, BlockBandedMatrices,  LinearAlgebra, Test
         testbandedoperator(A)
 
         @test norm(A\Fun(x.*f,rangespace(A))-(x.*f)) < 100eps()
+
+        @test (I : Chebyshev() → Chebyshev()) * Fun() ≈ Fun()
     end
 
     @testset "Derivative" begin


### PR DESCRIPTION
Fix #619 