### PR TITLE
Add transpose unit tests.

### DIFF
--- a/test/OperatorTest.jl
+++ b/test/OperatorTest.jl
@@ -307,4 +307,27 @@ using ApproxFun, BlockBandedMatrices,  LinearAlgebra, Test
         M = Multiplication(x, JacobiWeight(0,0,Chebyshev()))
         @test exp(M).f == Multiplication(exp(x), Chebyshev()).f
     end
+
+    @testset "Transpose" begin
+        let S = Chebyshev()
+            u, v = Fun(S, randn(8)), Fun(S, randn(8))
+            M = Multiplication(Fun(S, randn(8))) : S → S
+            @test dot(u, M*v) ≈ dot(v, M*u)
+            @test M*u ≈ M'*u
+        end
+        let S = JacobiWeight(1.,1.,Jacobi(1.,1.))
+            u, v = Fun(S, randn(8)), Fun(S, randn(8))
+            M = Multiplication(Fun(S, randn(8))) : S → S
+            @test dot(u, M*v) ≈ dot(v, M*u)
+            @test M*u ≈ M'*u
+        end
+        let S = JacobiWeight(2.,2.,Jacobi(1,1))
+            u, v = Fun(S, randn(8)), Fun(S, randn(8))
+            M = -Derivative(S)^2
+            @test dot(u, -v'') ≈ dot(-u'', v)
+            @test dot(u, M*v) ≈ dot(v, M*u)
+            @test M*u ≈ M'*u
+        end
+    end
+
 end


### PR DESCRIPTION
There is something wrong with transposes right now. 
The current definition of `TransposeOperator` seems to assume that the basis is orthonormal, `\|\psi_j\|=1`, but this isn't so for most spaces, and `M'[j,k] = M[k,j] * \|\psi_k\| / \|\psi_j\|`. See: https://github.com/JuliaApproximation/ApproxFun.jl/blob/522d95f6ddc7e8c1d92afce019c46293c7533bf5/src/Operators/general/TransposeOperator.jl#L25

I'd added a definition for `dot` to make up for the other bug to write the test
```
LinearAlgebra.dot(u::Fun, v::Fun) = last(cumsum(conj(Fun(u, Chebyshev(domain(u)))) * Fun(v, Chebyshev(domain(v)))))
```
I don't know how to write the dot product between two arbitrary Fun's properly, because I had some trouble when u and v are from different spaces and the conversion between the spaces was not implemented (didn't keep the test output, don't remember right now).