### PR TITLE
call deploydocs with arguments that Documenter currently supports

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,11 +22,5 @@ makedocs(
 
 
 deploydocs(
-    repo   = "github.com/JuliaApproximation/ApproxFun.jl.git",
-    devbranch = "development",
-    julia  = "0.7",
-    osname = "linux",
-    target = "build",
-    deps   = nothing,
-    make   = nothing
+    repo   = "github.com/JuliaApproximation/ApproxFun.jl.git"
     )


### PR DESCRIPTION
The julia and osname arguments no longer exist.  Those things are
supposed to be specified in travis.yml.

The development branch of ApproxFun is 9 months behind master, so
manual for the development version of ApproxFun should come from
the master branch.  Deploydocs does that by default.

The other arguments to deploydocs are the default values.  Specifying
them explicitly has no effect, except that there is more code for
maintainers to understand.