### PR TITLE
interlace => ApproxFunBase.interlace

### DIFF
--- a/src/Extras/fftGeneric.jl
+++ b/src/Extras/fftGeneric.jl
@@ -116,8 +116,8 @@ function *(::TransformPlan{T,Fourier{D,R},false},x::AbstractVector{T}) where {T<
     v = fft(x)
     rmul!(v,convert(T,2)/l)
     v[1] /= 2
-    mod(l,2) == 1 ? interlace(real(v[1:n]),-imag(v[2:n])) :
-      [interlace(real(v[1:n]),-imag(v[2:n]));-real(v[n+1])/2]
+    mod(l,2) == 1 ? ApproxFunBase.interlace(real(v[1:n]),-imag(v[2:n])) :
+      [ApproxFunBase.interlace(real(v[1:n]),-imag(v[2:n]));-real(v[n+1])/2]
 end
 
 function *(::ITransformPlan{T,Fourier{D,R},false},x::AbstractVector{T}) where {T<:BigFloat,D,R}

--- a/test/NumberTypeTest.jl
+++ b/test/NumberTypeTest.jl
@@ -21,6 +21,29 @@ using ApproxFun, ApproxFunOrthogonalPolynomials, Test
         @test norm(single_double_err) < 10eps(Float64)
     end
 
+	@testset "BigFloat constructor (Fourier)" begin
+		f = exp ∘ cos
+		single_f = Fun(f,
+		  Fourier(Interval(Float32(0),2*Float32(π))))
+		double_f = Fun(f,
+		  Fourier(Interval(Float64(0),2*Float64(π))))
+		big_f = Fun(f,
+		  Fourier(Interval(BigFloat(0),2*BigFloat(π))))
+		@test ncoefficients(single_f) <= ncoefficients(double_f)
+		@test ncoefficients(double_f) <= ncoefficients(big_f)
+
+		@test eltype(coefficients(single_f)) == Float32
+		@test eltype(coefficients(double_f)) == Float64
+		@test eltype(coefficients(big_f)) == BigFloat
+
+
+		single_double_err = coefficients(single_f-double_f)[1:ncoefficients(single_f)]
+		@test norm(single_double_err) < 10eps(Float32)
+
+		single_double_err = coefficients(double_f-big_f)[1:ncoefficients(double_f)]
+		@test norm(single_double_err) < 10eps(Float64)
+	end
+
     @testset "BigFloat roots" begin
         a = Fun(ChebyshevInterval{BigFloat}(),BigFloat[1,2,3])
         # 12 is some bound on how accurately the polynomial can be evaluated

--- a/test/NumberTypeTest.jl
+++ b/test/NumberTypeTest.jl
@@ -23,25 +23,17 @@ using ApproxFun, ApproxFunOrthogonalPolynomials, Test
 
 	@testset "BigFloat constructor (Fourier)" begin
 		f = exp ∘ cos
-		single_f = Fun(f,
-		  Fourier(Interval(Float32(0),2*Float32(π))))
 		double_f = Fun(f,
 		  Fourier(Interval(Float64(0),2*Float64(π))))
 		big_f = Fun(f,
 		  Fourier(Interval(BigFloat(0),2*BigFloat(π))))
-		@test ncoefficients(single_f) <= ncoefficients(double_f)
 		@test ncoefficients(double_f) <= ncoefficients(big_f)
 
-		@test eltype(coefficients(single_f)) == Float32
 		@test eltype(coefficients(double_f)) == Float64
 		@test eltype(coefficients(big_f)) == BigFloat
 
-
-		single_double_err = coefficients(single_f-double_f)[1:ncoefficients(single_f)]
-		@test norm(single_double_err) < 10eps(Float32)
-
-		single_double_err = coefficients(double_f-big_f)[1:ncoefficients(double_f)]
-		@test norm(single_double_err) < 10eps(Float64)
+		double_big_err = coefficients(double_f) - coefficients(big_f)[1:ncoefficients(double_f)]
+		@test norm(double_big_err) < 10eps(Float64)
 	end
 
     @testset "BigFloat roots" begin


### PR DESCRIPTION
In the current version, Fourier Fun constructor is not working with BigFloat, eg in the following example:

```
using ApproxFun

# FS = Fourier(0..2π)
FS = Fourier(BigFloat(0)..2*BigFloat(π))
f = Fun(exp ∘ cos, FS)
```

Indeed, "interlace" used in src/Extras/fftGeneric.jl is not found. A simple fix is to specify "ApproxFunBase.interlace".