### PR TITLE
Modernize documentation

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -1,3 +1,7 @@
+```@setup using-pkgs
+using ApproxFun, Random
+```
+
 # Frequently Asked Questions
 
 ## Approximating functions
@@ -6,108 +10,59 @@
 
 In the case where the grid is specified by `points(space,n)`, you can apply the default transform to data:
 
-```@meta
-DocTestSetup = quote
-    using ApproxFun
-end
-```
-
-```jldoctest
-julia> S = Chebyshev(1..2);
-
-julia> p = points(S,20); # the default grid
-
-julia> v = exp.(p);      # values at the default grid
-
-julia> f = Fun(S,ApproxFun.transform(S,v));
-
-julia> f(1.1)
-3.0041660239464347
-
-julia> exp(1.1)
-3.0041660239464334
+```@repl using-pkgs
+S = Chebyshev(1..2);
+p = points(S,20);  # the default grid
+v = exp.(p);  # values at the default grid
+f = Fun(S,ApproxFun.transform(S,v));
+f(1.1)
+exp(1.1)
 ```
 
 ApproxFun has no inbuilt support for interpolating functions at other sets of points, but this can be accomplished manually by evaluating the basis at the set of points and using \:
 
-```jldoctest
-julia> S = Chebyshev(1..2);
-
-julia> n = 50;
-
-julia> p = range(1,stop=2,length=n);   # a non-default grid
-
-julia> v = exp.(p);           # values at the non-default grid
-
-julia> V = Array{Float64}(undef,n,n); # Create a Vandermonde matrix by evaluating the basis at the grid
-
-julia> for k = 1:n
-           V[:,k] = Fun(S,[zeros(k-1);1]).(p)
-       end
-
-julia> f = Fun(S,V\v);
-
-julia> f(1.1)
-3.0041660228311926
-
-julia> exp(1.1)
-3.0041660239464334
+```@repl using-pkgs
+S = Chebyshev(1..2);
+n = 50;
+p = range(1,stop=2,length=n);  # a non-default grid
+v = exp.(p);  # values at the non-default grid
+V = Array{Float64}(undef,n,n);  # Create a Vandermonde matrix by evaluating the basis at the grid
+for k = 1:n
+   V[:,k] = Fun(S,[zeros(k-1);1]).(p)
+end
+f = Fun(S,V\v);
+f(1.1)
+exp(1.1)
 ```
 
 Note that an evenly spaced grid suffers from instability for large `n`.  The easiest way around this is to use least squares with more points than coefficients, instead of interpolation:
 
-```jldoctest
-julia> S = Chebyshev(1..2);
-
-julia> n = 100; m = 50;
-
-julia> p = range(1,stop=2,length=n);   # a non-default grid
-
-julia> v = exp.(p);           # values at the non-default grid
-
-julia> V = Array{Float64}(undef,n,m); # Create a Vandermonde matrix by evaluating the basis at the grid
-
-julia> for k = 1:m
-           V[:,k] = Fun(S,[zeros(k-1);1]).(p)
-       end
-
-julia> f = Fun(S,V\v);
-
-julia> f(1.1)
-3.004166023946434
-
-julia> exp(1.1)
-3.0041660239464334
+```@repl using-pkgs
+S = Chebyshev(1..2);
+n = 100; m = 50;
+p = range(1,stop=2,length=n);  # a non-default grid
+v = exp.(p);  # values at the non-default grid
+V = Array{Float64}(undef,n,m);  # Create a Vandermonde matrix by evaluating the basis at the grid
+for k = 1:m
+   V[:,k] = Fun(S,[zeros(k-1);1]).(p)
+end
+f = Fun(S,V\v);
+f(1.1)
+exp(1.1)
 ```
 
 We can use this same approach for multivariate functions:
 
-```jldoctest
-julia> S = Chebyshev(0..1)^2;
-
-julia> n = 1000; m = 50;
-
-julia> Random.seed!(0); x = rand(n); y = rand(n);
-
-julia> v = exp.(x .* cos(y));  # values at the non-default grid
-
-julia> V = Array{Float64}(undef,n,m); # Create a Vandermonde matrix by evaluating the basis at the grid
-
-julia> for k = 1:m
-          V[:,k] = Fun(S,[zeros(k-1);1]).(x,y)
-       end
-
-
-julia> f = Fun(S,V\v);
-
-julia> f(0.1,0.2)
-1.1029700685084018
-
-julia> exp(0.1*cos(0.2))
-1.1029701284210731
-```
-
-
-```@meta
-DocTestSetup = nothing
+```@repl using-pkgs
+S = Chebyshev(0..1)^2;
+n = 1000; m = 50;
+Random.seed!(0); x = rand(n); y = rand(n);
+v = exp.(x .* \cos{y});  # values at the non-default grid
+V = Array{Float64}(undef,n,m);  # Create a Vandermonde matrix by evaluating the basis at the grid
+for k = 1:m
+   V[:,k] = Fun(S,[zeros(k-1);1]).(x,y)
+end
+f = Fun(S,V\v);
+f(0.1,0.2)
+exp(0.1*cos(0.2))
 ```

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -57,7 +57,7 @@ We can use this same approach for multivariate functions:
 S = Chebyshev(0..1)^2;
 n = 1000; m = 50;
 Random.seed!(0); x = rand(n); y = rand(n);
-v = exp.(x .* \cos{y});  # values at the non-default grid
+v = exp.(x .* cos.(y));  # values at the non-default grid
 V = Array{Float64}(undef,n,m);  # Create a Vandermonde matrix by evaluating the basis at the grid
 for k = 1:m
    V[:,k] = Fun(S,[zeros(k-1);1]).(x,y)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,84 +1,75 @@
+```@setup using-pkgs
+using ApproxFun
+```
+
 # ApproxFun.jl Documentation
 
-
-
-ApproxFun is a package for approximating and manipulating functions,
-and for solving differential and integral equations.  
+ApproxFun is a package for approximating and manipulating functions, and for solving differential and integral equations.  
 
 ## Introduction
 
-A basic approach of computational mathematics that ApproxFun exploits is expansion
-in a basis
+A basic approach of computational mathematics that ApproxFun exploits is expansion in a basis
 
-$$f(x) \approx \sum_{k=1}^n c_k \psi_k(x)$$
+```math
+\mathop{f}(x) \approx \sum_{k=1}^n c_k \mathop{ψ}_k(x).
+```
 
-Some traditional examples of bases $\psi_1(x),\psi_2(x),\ldots$ are
-1. Taylor series: $1,z,z^2,\ldots$
-2. Fourier series (for periodic functions on `0..2π`): $1,\sin x, \cos x, \sin 2 x, \ldots$
-3. Chebyshev series (for non-periodic functions on `-1..1`): $1,x,\cos 2 \hbox{acos}\, x, \cos 3 \hbox{acos}\, x, \ldots$
+Some traditional examples of bases ``\mathop{ψ}_1(x), \mathop{ψ}_2(x), …`` are
 
-In ApproxFun, functions are represented by a `Fun` with two components: `space`,
-which dictates the basis and `coefficients` which is a finite vector of coefficients.  Note that each `Fun` can have a different length vector of
-coefficients, allowing for approximation of many different functions to high
-accuracy.  
+1. Taylor series: ``1, x, x^2, …``
+2. Fourier series (for periodic functions on `0..2π`): ``1, \sin{x}, \cos{x}, \sin{2x}, …``
+3. Chebyshev series (for non-periodic functions on `-1..1`): ``1, x, \cos(2\arccos{x}), \cos(3\arccos{x}), …``
+
+In ApproxFun, functions are represented by a `Fun` with two components: `space`, which dictates the basis and `coefficients` which is a finite vector of coefficients.  Note that each `Fun` can have a different length vector of coefficients, allowing for approximation of many different functions to high accuracy.  
 
 The approximation by a `Fun` can be determined by a variety of methods:
 
 (1) Explicitly specifying the coefficients:
-```julia
-julia> f = Fun(Taylor(),[1,2,3]) # Represents 1 + 2z + 3z^2
-Fun(Taylor(🕒),[1.0,2.0,3.0])
 
-julia> f(1.0)
-6.0
+```@repl using-pkgs
+f = Fun(Taylor(),[1,2,3])  # Represents 1 + 2x + 3x^2
+f(1.0)
 ```
-(2) Constructors take in a `Function` and adaptively determine the
-    number of coefficients.  For example,
-```julia
-julia> Fun(exp)
-Fun(Chebyshev(【-1.0,1.0】),[1.26607,1.13032,0.271495,0.0443368,0.00547424,0.000542926,4.49773e-5,3.19844e-6,1.99212e-7,1.10368e-8,5.5059e-10,2.49797e-11,1.03911e-12,3.99195e-14])
+
+(2) Constructors take in a `Function` and adaptively determine the number of coefficients.  For example,
+
+```@repl using-pkgs
+Fun(exp)
 ```
-determines that `f` can be approximated to roughly machine precision using
-14 coefficients.  See [Constructors](usage/constructors.md) for more information.
+
+determines that `f` can be approximated to roughly machine precision using 14 coefficients.  See [Constructors](usage/constructors.md) for more information.
 
 (3) Manipulation of `Fun`s give new `Fun`s, where the number of coefficients is determined from the input.  The simplest example is addition, which for compatible bases is just padding the vectors to the same length and adding.  
-```julia
-julia> a = Fun(cos,Chebyshev()); ncoefficients(a)
-13
 
-julia> b = Fun(x->cos(10cos(x^2)),Chebyshev()); ncoefficients(b)
-51
-
-julia> ncoefficients(a+b)
-51
+```@repl using-pkgs
+a = Fun(cos,Chebyshev()); ncoefficients(a)
+b = Fun(x->cos(10cos(x^2)),Chebyshev()); ncoefficients(b)
+ncoefficients(a+b)
 ```
+
 On the other hand, multiplication results in an approximation with more coefficients than either `a` or `b`, so that the result approximates the true `a*b` to roughly machine accuracy:
+
+```@setup ab
+using ApproxFun
+a = Fun(cos,Chebyshev())
+b = Fun(x->cos(10cos(x^2)),Chebyshev())
 ```
-julia> ncoefficients(a*b)
-63
 
-julia> a(0.1)*b(0.1) - (a*b)(0.1)
-1.1102230246251565e-16
+```@repl ab
+ncoefficients(a*b)
+a(0.1)*b(0.1) - (a*b)(0.1)
 ```
 
+The example of multiplication highlights the importance of adaptivity: if with a fixed discretization size, operations like multiplication would lose accuracy when the true function is no longer resolved by the discretization.  More complicated examples are solving differential equations, where the coefficients of the solution can be determined adaptively, see [Equations](usage/equations.md).
 
-The example of multiplication highlights the importance of adaptivity: if with a fixed discretization size, operations like multiplication would lose accuracy when the true function is no longer resolved by the discretization.  More complicated examples are solving differential equations, where the
-coefficients of the solution can be determined adaptively, see [Equations](usage/equations.md).
-
-
-
-ApproxFun supports a number of different spaces, as described in [Spaces](usage/spaces.md).  A key component of ApproxFun is support for interaction between different
-spaces.  This is crucial for efficient solution of differential equations, where linear operators are described as acting between different spaces, see [Operators](usage/operators.md).  
-
+ApproxFun supports a number of different spaces, as described in [Spaces](usage/spaces.md).  A key component of ApproxFun is support for interaction between different spaces.  This is crucial for efficient solution of differential equations, where linear operators are described as acting between different spaces, see [Operators](usage/operators.md).  
 
 ## Contents
 
-
-
 ```@contents
-Pages = ["usage/constructors.md",
-         "usage/domains.md",
+Pages = ["usage/domains.md",
          "usage/spaces.md",
+         "usage/constructors.md",
          "usage/operators.md",
          "usage/equations.md",
          "faq.md",

--- a/docs/src/usage/constructors.md
+++ b/docs/src/usage/constructors.md
@@ -1,50 +1,32 @@
+```@setup using-pkgs
+using ApproxFun
+```
+
 # Constructors
 
-`Fun`s in ApproxFun are instances of Julia types with one field to store coefficients and another
-to describe the function space. Similarly, each function space has one field describing
-its domain, or another function space. Let's explore:
+`Fun`s in ApproxFun are instances of Julia types with one field to store coefficients and another to describe the function space. Similarly, each function space has one field describing its domain, or another function space. Let's explore:
 
-
-```@meta
-DocTestSetup = quote
-    using ApproxFun
-end
+```@repl using-pkgs
+x = Fun(identity,-1..1);
+f = exp(x);
+g = f/sqrt(1-x^2);
+space(f)  # Output is pretty version of Chebyshev(Interval(-1.0,1.0))
+space(g)  # Output is pretty version of JacobiWeight(-0.5,-0.5,Interval(-1.0,1.0))
 ```
 
+The absolute value is another case where the space of the output is inferred from the operation:
 
-```jldoctest
-julia> x = Fun(identity,-1..1);
-
-julia> f = exp(x);
-
-julia> g = f/sqrt(1-x^2);
-
-julia> space(f)   # Output is pretty version of Chebyshev(Interval(-1.0,1.0))
-Chebyshev(【-1.0,1.0】)
-
-julia> space(g)   # Output is pretty version of  JacobiWeight(-0.5,-0.5,Interval(-1.0,1.0))
-(1-x^2)^-0.5[Chebyshev(【-1.0,1.0】)]
-```
-
-The absolute value is
-another case where the space of the output is inferred from the operation:
-
-```jldoctest
-julia> f = Fun(x->cospi(5x),-1..1);
-
-julia> g = abs(f);
-
-julia> space(f)
-Chebyshev(【-1.0,1.0】)
-
-julia> space(g)
-Chebyshev(【-1.0,-0.9000000000000002】)⨄Chebyshev(【-0.9000000000000002,-0.6999999999999996】)⨄Chebyshev(【-0.6999999999999996,-0.5000000000000001】)⨄Chebyshev(【-0.5000000000000001,-0.30000000000000043】)⨄Chebyshev(【-0.30000000000000043,-0.09999999999999962】)⨄Chebyshev(【-0.09999999999999962,0.10000000000000053】)⨄Chebyshev(【0.10000000000000053,0.29999999999999966】)⨄Chebyshev(【0.29999999999999966,0.500000000000001】)⨄Chebyshev(【0.500000000000001,0.6999999999999998】)⨄Chebyshev(【0.6999999999999998,0.9000000000000006】)⨄Chebyshev(【0.9000000000000006,1.0】)
+```@repl using-pkgs
+f = Fun(x->cospi(5x),-1..1);
+g = abs(f);
+space(f)
+space(g)
 ```
 
 ## Convenience constructors
 
-The default space is `Chebyshev`, which can represent non-periodic functions on intervals.  Each `Space` type has a default domain: for `Chebyshev` this is `-1..1`, for Fourier and Laurent this is `-π..π`.  Thus the following
-are equivalent:
+The default space is `Chebyshev`, which can represent non-periodic functions on intervals.  Each `Space` type has a default domain: for `Chebyshev` this is `-1..1`, for Fourier and Laurent this is `-π..π`.  Thus the following are equivalent:
+
 ```julia
 Fun(exp,Chebyshev(Interval(-1,1)))
 Fun(exp,Chebyshev(ChebyshevInterval()))
@@ -55,8 +37,9 @@ Fun(exp,ChebyshevInterval())
 Fun(exp,Interval(-1,1))
 Fun(exp)
 ```
-If a function is not specified, then it is taken to be `identity`.  Thus we have the
-following equivalent constructions:
+
+If a function is not specified, then it is taken to be `identity`.  Thus we have the following equivalent constructions:
+
 ```julia
 x = Fun(identity, -1..1)
 x = Fun(-1..1)
@@ -64,39 +47,41 @@ x = Fun(identity)
 x = Fun()
 ```
 
-
 ## Specifying coefficients explicitly
 
-It is sometimes necessary to specify coefficients explicitly.  This is possible
-via specifying the space followed by a vector of coefficients:
-```jldoctest
-julia> f = Fun(Taylor(), [1,2,3]);  # represents 1 + 2z + 3z^2
+It is sometimes necessary to specify coefficients explicitly.  This is possible via specifying the space followed by a vector of coefficients:
 
-julia> f(0.1)
-1.23
-
-julia> 1 + 2*0.1 + 3*0.1^2
-1.23
+```@repl using-pkgs
+f = Fun(Taylor(), [1,2,3]);  # represents 1 + 2z + 3z^2
+f(0.1)
+1 + 2*0.1 + 3*0.1^2
 ```
 
-In higher dimensions, ApproxFun will sum products of the 1D basis functions. So if $T_i(x)$ is the $i$th basis function, then a 2D function can be approximated as the following:
-$$f(x, \, y) = \sum_{i, j} c_{i,j} \, T_i(x) \, T_j(y).$$
+In higher dimensions, ApproxFun will sum products of the 1D basis functions. So if ``\mathop{T}_i(x)`` is the ``i``th basis function, then a 2D function can be approximated as the following:
 
-The products will be ordered lexicographically by the degree of the polynomial, i.e. in the order $\{T_0(x) \, T_0(y), \, T_0(x) \, T_1(y),  \, T_1(x) \, T_0(y),  \, T_0(x) \, T_2(y),  \, T_1(x) \, T_1(y),  \, T_2(x) \, T_0(y),  \, ... \}$. For example, if we are in the two dimensional CosSpace space and we have coefficients $\{c_1, c_2, c_3\}$, then
-$$ f(x, y) = c_1 \cos(0 x) \cos(0 y) + c_2 \cos(0 x) \cos(1 y) + c_3 \cos(1 x) \cos(0 y). $$
+```math
+\mathop{f}(x,y) = \sum_{i,j} c_{ij} \mathop{T}_i(x) \mathop{T}_j(y).
+```
+
+The products will be ordered lexicographically by the degree of the polynomial, i.e., in the order
+
+```math
+\mathop{T}_0(x) \mathop{T}_0(y),\ \mathop{T}_0(x) \mathop{T}_1(y),\ \mathop{T}_1(x) \mathop{T}_0(y),\ \mathop{T}_0(x) \mathop{T}_2(y),\ \mathop{T}_1(x) \mathop{T}_1(y),\ \mathop{T}_2(x) \mathop{T}_0(y),\ ….
+```
+
+For example, if we are in the two dimensional CosSpace space and we have coefficients ``\{c_1, c_2, c_3\}``, then
+
+```math
+\mathop{f}(x, y) = c_1 \cos(0 x) \cos(0 y) + c_2 \cos(0 x) \cos(1 y) + c_3 \cos(1 x) \cos(0 y).
+```
 
 This is illustrated in the following code:
-```jldoctest
-julia> f = Fun(CosSpace()^2, [1,2,3])
-Fun(CosSpace(【0.0,6.283185307179586❫)⊗CosSpace(【0.0,6.283185307179586❫),[1.0,2.0,3.0])
 
-julia> f(1,2)
-1.7886132445101346
-
-julia> 1cos(0*1)*cos(0*2) + 2cos(0*1)*cos(1*2) + 3cos(1*1)*cos(0*2)
-1.7886132445101346
+```@repl using-pkgs
+f = Fun(CosSpace()^2, [1,2,3])
+f(1,2)
+1cos(0*1)*cos(0*2) + 2cos(0*1)*cos(1*2) + 3cos(1*1)*cos(0*2)
 ```
-
 
 ## Using ApproxFun for “manual” interpolation
 
@@ -105,8 +90,3 @@ The ApproxFun package for Julia implements all of the necessary operations for C
 Normally, you give it a function f and a domain d, and construct the Chebyshev interpolant by `fc = Fun(f, d)`. The ApproxFun package figures out the necessary number of Chebyshev points (i.e., the polynomial order) required to interpolate f to nearly machine precision, so that subsequent operations on fc can be viewed as "exact".
 
 However, in cases where the function to be interpolated is extremely expensive, and possibly even is evaluated by an external program, it is convenient to be able to decide on the desired Chebyshev order in advance, evaluate the function at those points "manually", and then construct the Chebyshev interpolant. An example showing how to do this is given in the [ApproxFun FAQ](../faq.md).
-
-
-```@meta
-DocTestSetup = nothing
-```

--- a/docs/src/usage/domains.md
+++ b/docs/src/usage/domains.md
@@ -1,31 +1,26 @@
 # Domains
 
-`Domain` is an abstract type whose subtypes represent oriented domains on which
-we wish to approximate functions.  
-Examples include `Interval`, `Ray`, `Line` and `Arc`.  
-Periodic domains include `PeriodicSegment`, `PeriodicLine` and `Circle`.
-
+`Domain` is an abstract type whose subtypes represent oriented domains on which we wish to approximate functions.  Examples include `Interval`, `Ray`, `Line` and `Arc`.  Periodic domains include `PeriodicSegment`, `PeriodicLine` and `Circle`.
 
 ## Relationship with spaces
 
-Every domain `d` has a default space, constructed via `Space(d)`.  For example,
-the default space for `ChebyshevInterval()` is `Chebyshev(ChebyshevInterval())`, which is
-efficient for representing smooth functions.  On the other hand, the
-default space for `PeriodicSegment()` is `Fourier(PeriodicSegment())`, which
-uses trigonometric polynomials to approximate periodic functions.  
-
+Every domain `d` has a default space, constructed via `Space(d)`.  For example, the default space for `ChebyshevInterval()` is `Chebyshev(ChebyshevInterval())`, which is efficient for representing smooth functions.  On the other hand, the default space for `PeriodicSegment()` is `Fourier(PeriodicSegment())`, which uses trigonometric polynomials to approximate periodic functions.  
 
 ## Manipulating domains
 
 Domains can be manipulated to make more complicated domains.  For example, you can take the union of an interval and a circle
+
 ```julia
-ChebyshevInterval() ∪ Circle(3,0.5)    # equivalent to union(ChebyshevInterval(),Circle(3,0.5))
+ChebyshevInterval() ∪ Circle(3,0.5)  # equivalent to union(ChebyshevInterval(),Circle(3,0.5))
 ```
 and the following creates a rectangle `[0,1]^2`:
+
 ```julia
 rect=Interval(0,1)^2
 ```
+
 Some other set operations are partially implemented:
+
 ```julia
-Interval(0,2) ∩ ChebyshevInterval() # returns Interval(0,1)
+Interval(0,2) ∩ ChebyshevInterval()  # returns Interval(0,1)
 ```

--- a/docs/src/usage/equations.md
+++ b/docs/src/usage/equations.md
@@ -1,211 +1,203 @@
+```@setup using-pkgs
+using ApproxFun, LinearAlgebra
+```
+
 # Linear equations
 
-Linear equations such as ordinary and partial differential equations,
- fractional differential equations and integral equations can be solved using ApproxFun.
-This is accomplished using `A\b` where `A` is an `Operator` and `b`
-is a `Fun`.  As a simple example, consider the equation
+Linear equations such as ordinary and partial differential equations, fractional differential equations and integral equations can be solved using ApproxFun.  This is accomplished using `A\b` where `A` is an `Operator` and `b` is a `Fun`.  As a simple example, consider the equation
 
-$$u'(\theta) + cu(\theta) = \cos\theta$$
-
-where we want a solution that is periodic on $[0,2\pi)$.  This can be solved succinctly
-as follows:
-```@meta
-DocTestSetup = quote
-    using ApproxFun
-end
+```math
+\mathop{u}'(θ) + c \mathop{u}(θ) = \cos{θ},
 ```
-```jldoctest
-julia> b = Fun(cos,Fourier());
 
-julia> c = 0.1; u = (𝒟+c*I)\b;
+where we want a solution that is periodic on ``[0,2π)``.  This can be solved succinctly as follows:
 
-julia> u(0.6)
-0.64076835137228
-
-julia> (c*cos(0.6)+sin(0.6))/(1+c^2)  # exact solution
-0.6407683513722804
+```@repl using-pkgs
+b = Fun(cos,Fourier());
+c = 0.1; u = (𝒟+c*I)\b;
+u(0.6)
+(c*cos(0.6)+sin(0.6))/(1+c^2)  # exact solution
 ```
+
 Recall that `𝒟` is an alias to `Derivative() == Derivative(UnsetSpace(),1)`.
 
 As another example, consider the Fredholm integral equation
 
-$$u + {\rm e}^x \int_{-1}^1 \cos x \, u(x) {\rm d}x = \cos {\rm e}^x$$
+```math
+\mathop{u} + \mathop{e}^x \int_{-1}^1 \cos{x} \mathop{u}(x) \mathop{dx} = \cos{\mathop{e}^x}.
+```
 
 We can solve this equation as follows:
-```jldoctest
-julia> Σ = DefiniteIntegral(Chebyshev()); x = Fun();
 
-julia> u = (I+exp(x)*Σ[cos(x)]) \ cos(exp(x));
-
-julia> u(0.1)
-0.21864294855628802
+```@repl using-pkgs
+Σ = DefiniteIntegral(Chebyshev()); x = Fun();
+u = (I+exp(x)*Σ[cos(x)]) \ cos(exp(x));
+u(0.1)
 ```
+
 Note that we used the syntax `op[f::Fun]`, which is a shorthand for `op*Multiplication(f)`.
 
 ## Boundary conditions
 
-Incorporating boundary conditions into differential equations is important
-so that the equation is well-posed.  This is accomplished via combining
-operators and functionals (i.e., `1 × ∞` operators).  As a simple example, consider the first order
-initial value problem
+Incorporating boundary conditions into differential equations is important so that the equation is well-posed.  This is accomplished via combining operators and functionals (i.e., `1 × ∞` operators).  As a simple example, consider the first order initial value problem
 
-$$u' = t u \qquad\hbox{and}\qquad u(0) = 1$$
-
-To pose this in ApproxFun, we want to find a `u` such that `Evaluation(0)*u == 1`
-and `(𝒟 - t)*u == 0`.  This is accomplished via:
-```jldoctest
-julia> t = Fun(0..1);
-
-julia> u = [Evaluation(0); 𝒟 - t]  \ [1;0];
-
-julia> u(0)
-0.9999999999999996
-
-julia> norm(u'-t*u)
-1.2016080299388273e-16
+```math
+\begin{gathered}
+    \mathop{u}' = t \mathop{u}, \\
+    \mathop{u}(0) = 1.
+\end{gathered}
 ```
-Behind the scenes, the `Vector{Operator{T}}` representing the functionals
-and operators are combined into a single `InterlaceOperator`.
 
-A common usage is two-point boundary value problems. Consider
-the singularly perturbed boundary value problem:
+To pose this in ApproxFun, we want to find a `u` such that `Evaluation(0)*u == 1` and `(𝒟 - t)*u == 0`.  This is accomplished via:
 
-$$\epsilon u''-xu'+u = u \qquad u(-1) = 1,\quad u(1) = 2$$
+```@repl using-pkgs
+t = Fun(0..1);
+u = [Evaluation(0); 𝒟 - t]  \ [1;0];
+u(0)
+norm(u'-t*u)
+```
+
+Behind the scenes, the `Vector{Operator{T}}` representing the functionals and operators are combined into a single `InterlaceOperator`.
+
+A common usage is two-point boundary value problems. Consider the singularly perturbed boundary value problem:
+
+```math
+\begin{gathered}
+    ϵ \mathop{u}'' - x \mathop{u}' + \mathop{u} = \mathop{u}, \\
+    \mathop{u}(-1) = 1, \mathop{u}(1) = 2.
+\end{gathered}
+```
 
 This can be solved in ApproxFun via:
-```jldoctest
-julia> x = Fun();
 
-julia> u = [Evaluation(-1);
-            Evaluation(1);
-            1/70*𝒟^2-x*𝒟+I] \ [1,2,0];
-
-julia> u(0.1)
-0.049999999999960326
+```@repl using-pkgs
+x = Fun();
+u = [Evaluation(-1);
+     Evaluation(1);
+     1/70*𝒟^2-x*𝒟+I] \ [1,2,0];
+u(0.1)
 ```
+
 Note in this case the space is inferred from the variable coefficient `x`.
 
 This ODE can also be solved using the `Dirichlet` operator:
-```jldoctest
-julia> x = Fun();
 
-julia> u = [Dirichlet();
-            1/70*𝒟^2-x*𝒟+I] \ [[1,2],0];
-
-julia> u(0.1)
-0.04999999999996019
+```@repl using-pkgs
+x = Fun();
+u = [Dirichlet();
+     1/70*𝒟^2-x*𝒟+I] \ [[1,2],0];
+u(0.1)
 ```
 
 ## Eigenvalue Problems
 
-In analogy to linear algebra, many differential equations may be posed as eigenvalue problems. That is, for some differential operator $L$, there are a family of functions $u_i(x)$ such that
-$$L~u_i(x) = \lambda_i u_i(x)$$
-where $\lambda_i$ is the $i^{th}$ eigenvalue of the $L$ and has a corresponding *eigenfunction* $u_i(x)$. A classic eigenvalue problem is known as the quantum harmonic oscillator where
-$$L = -\frac{1}{2}\frac{d^2}{dx^2} + \frac{1}{2} x^2$$
-and one demands that $u(\infty) = u(-\infty) = 0$. Because we expect the solutions to be exponentially suppressed for large $x$, we can approximate this with Dirichlet boundary conditions at a 'reasonably large' $x$ without much difference.
+In analogy to linear algebra, many differential equations may be posed as eigenvalue problems. That is, for some differential operator ``\mathop{L}``, there are a family of functions ``\mathop{u}_i(x)`` such that
+
+```math
+\mathop{L} \mathop{u}_i(x) = λ_i \mathop{u}_i(x),
+```
+
+where ``λ_i`` is the ``i^{th}`` eigenvalue of the ``L`` and has a corresponding *eigenfunction* ``\mathop{u}_i(x)``. A classic eigenvalue problem is known as the quantum harmonic oscillator where
+
+```math
+\mathop{L} = -\frac{1}{2}\frac{\mathop{d}^2}{\mathop{dx}^2} + \frac{1}{2} x^2,
+```
+
+and one demands that ``\mathop{u}(∞) = \mathop{u}(-∞) = 0``. Because we expect the solutions to be exponentially suppressed for large ``x``, we can approximate this with Dirichlet boundary conditions at a 'reasonably large' ``x`` without much difference.
 
 We can express this in ApproxFun as the following:
-```jldoctest
+
+```julia
 x = Fun(-8 .. 8)
 L = -𝒟^2/2 + x^2/2
 S = space(x)
 B = Dirichlet(S)
 λ, v = ApproxFun.eigs(B, L, 500,tolerance=1E-10)
 ```
-note that boundary conditions must be specified in the call to `eigs`. Plotting the first $20$ eigenfunctions offset vertically by their eigenvalue, we see
+
+Note that boundary conditions must be specified in the call to `eigs`. Plotting the first ``20`` eigenfunctions offset vertically by their eigenvalue, we see
 
 ![harmonic_eigs](../assets/Harmonic_eigs.pdf)
 
 If the solutions are not relatively constant near the boundary then one should push the boundaries further out.
 
-For problems with different contraints or boundary conditions, `B` can be any zero functional constraint, eg. `DefiniteIntegral()`.
+For problems with different contraints or boundary conditions, `B` can be any zero functional constraint, e.g., `DefiniteIntegral()`.
 
 ## Systems of equations
 
-Systems of equations can be handled by creating a matrix of operators and
-functionals.  For example, we can solve the system
+Systems of equations can be handled by creating a matrix of operators and functionals.  For example, we can solve the system
 
-$$\begin{align*}
-    u'' - u + 2v &= {\rm e}^x  \cr
-    v' + v &= cos(x) \cr
-    u(-1) &= u'(-1) = v(-1) = 0
-\end{align*}$$
+```math
+\begin{gathered}
+    \mathop{u}'' - \mathop{u} + 2 \mathop{v} = \mathop{e}^x,  \\
+    \mathop{v}' + \mathop{v} = \cos{x}, \\
+    \mathop{u}(-1) = \mathop{u}'(-1) = \mathop{v}(-1) = 0
+\end{gathered}
+```
 
 using the following code:
-```jldoctest
-julia> x = Fun(); B = Evaluation(Chebyshev(),-1);
 
-julia> A = [B      0;
-            B*𝒟    0;
-            0      B;
-            𝒟^2-I  2I;
-            I      𝒟+I];
-
-julia> u,v = A\[0;0;0;exp(x);cos(x)];
-
-julia> u(-1),u'(-1),v(-1)
-(-4.163336342344337e-17,-2.7755575615628914e-16,-2.220446049250313e-16)
-
-julia> norm(u''-u+2v-exp(x))
-5.981056979045254e-16
-
-julia> norm(u + v'+v-cos(x))
-2.3189209621240424e-16
+```@repl using-pkgs
+x = Fun(); B = Evaluation(Chebyshev(),-1);
+A = [B      0;
+     B*𝒟    0;
+     0      B;
+     𝒟^2-I  2I;
+     I      𝒟+I];
+u,v = A\[0;0;0;exp(x);cos(x)];
+u(-1),u'(-1),v(-1)
+norm(u''-u+2v-exp(x))
+norm(u + v'+v-cos(x))
 ```
-In this example, the automatic space detection failed and so we needed
-to specify explicitly that the domain space for `B` is `Chebyshev()`.
 
+In this example, the automatic space detection failed and so we needed to specify explicitly that the domain space for `B` is `Chebyshev()`.
 
 ## QR Factorization
 
-Behind the scenes, `A\b` where `A` is an `Operator` is implemented via
-an adaptive QR factorization.  That is, it is equivalent to
-`qr(A)\b`.  (There is a subtlety here in space inferring: `A\b` can use
-    both `A` and `b` to determine the domain space, while `qr(A)` only
-    sees the operator `A`.)
-      Note that `qr` adaptively caches a partial QR Factorization
-as it is applied to different right-hand sides, so the same operator can be
-inverted much more efficiently in subsequent problems.
-
+Behind the scenes, `A\b` where `A` is an `Operator` is implemented via an adaptive QR factorization.  That is, it is equivalent to `qr(A)\b`.  (There is a subtlety here in space inferring: `A\b` can use both `A` and `b` to determine the domain space, while `qr(A)` only sees the operator `A`.)  Note that `qr` adaptively caches a partial QR Factorization
+as it is applied to different right-hand sides, so the same operator can be inverted much more efficiently in subsequent problems.
 
 ## Partial differential equations
 
 Partial differential operators are also supported.  Here's an example
 of solving the Poisson equation with zero boundary conditions:
+
 ```julia
 d = Domain(-1..1)^2
 x,y = Fun(d)
 f = exp.(-10(x+0.3)^2-20(y-0.2)^2)  # use broadcasting as exp(f) not implemented in 2D
-A = [Dirichlet(d);Δ]              # Δ is an alias for Laplacian()
-@time u = A \ [zeros(∂(d));f]     #4s for ~3k coefficients
+A = [Dirichlet(d);Δ]  # Δ is an alias for Laplacian()
+@time u = A \ [zeros(∂(d));f]  # 4s for ~3k coefficients
 ```
-Using a QR Factorization
-reduces the cost of subsequent calls substantially:
+
+Using a QR Factorization reduces the cost of subsequent calls substantially:
+
 ```julia
 QR = qr(A)
-@time QR \ [zeros(∂(d));f]   # 4s
+@time QR \ [zeros(∂(d));f]  # 4s
 g = exp.(-10(x+0.2)^2-20(y-0.1)^2)
 @time QR \ [zeros(∂(d));g]  # 0.09s
 ```
 
-Many PDEs have weak singularities at the corners, in which case it is beneficial to
-specify a tolerance to reduce the time:
+Many PDEs have weak singularities at the corners, in which case it is beneficial to specify a tolerance to reduce the time:
+
 ```julia
 \(A, [zeros(∂(d));f]; tolerance=1E-6)
 ```
 
-
 ## Nonlinear equations
 
-There is preliminary support for nonlinear equations, via Newton iteration
-in function space.  Here is a simple two-point boundary value problem:
+There is preliminary support for nonlinear equations, via Newton iteration in function space.  Here is a simple two-point boundary value problem:
 
-$$\begin{align*}
-    \epsilon u'' &+ 6(1-x^2)u' +u^2=1 \cr
-    u(-1)&=u(1)=0
-\end{align*}$$
+```math
+\begin{gathered}
+    ϵ \mathop{u}'' + 6(1-x^2) \mathop{u}' + \mathop{u}^2=1, \\
+    \mathop{u}(-1) = \mathop{u}(1) = 0.
+\end{gathered}
+```
 
 This can be solved using
+
 ```julia
 x = Fun()
 N = u -> [u(-1.)-c; u(1.); ε*u'' + 6*(1-x^2)*u' + u^2 - 1.0]

--- a/docs/src/usage/equations.md
+++ b/docs/src/usage/equations.md
@@ -130,7 +130,7 @@ Systems of equations can be handled by creating a matrix of operators and functi
 ```math
 \begin{gathered}
     \mathop{u}'' - \mathop{u} + 2 \mathop{v} = \mathop{e}^x,  \\
-    \mathop{v}' + \mathop{v} = \cos{x}, \\
+    \mathop{u} + \mathop{v}' + \mathop{v} = \cos{x}, \\
     \mathop{u}(-1) = \mathop{u}'(-1) = \mathop{v}(-1) = 0
 \end{gathered}
 ```

--- a/docs/src/usage/equations.md
+++ b/docs/src/usage/equations.md
@@ -108,7 +108,7 @@ and one demands that ``\mathop{u}(∞) = \mathop{u}(-∞) = 0``. Because we expe
 We can express this in ApproxFun as the following:
 
 ```julia
-x = Fun(-8 .. 8)
+x = Fun(-8..8)
 L = -𝒟^2/2 + x^2/2
 S = space(x)
 B = Dirichlet(S)

--- a/docs/src/usage/equations.md
+++ b/docs/src/usage/equations.md
@@ -71,10 +71,10 @@ A common usage is two-point boundary value problems. Consider the singularly per
 This can be solved in ApproxFun via:
 
 ```@repl using-pkgs
-x = Fun();
+ϵ = 1/70; x = Fun();
 u = [Evaluation(-1);
      Evaluation(1);
-     1/70*𝒟^2-x*𝒟+I] \ [1,2,0];
+     ϵ*𝒟^2-x*𝒟+I] \ [1,2,0];
 u(0.1)
 ```
 
@@ -196,10 +196,12 @@ There is preliminary support for nonlinear equations, via Newton iteration in fu
 \end{gathered}
 ```
 
-This can be solved using
+This can be solved as follows:
 
-```julia
-x = Fun()
-N = u -> [u(-1.)-c; u(1.); ε*u'' + 6*(1-x^2)*u' + u^2 - 1.0]
-u = newton(N,u0)
+```@repl using-pkgs
+ϵ = 1/70; x = Fun();
+N = u -> [u(-1); u(1); ϵ*u''+6*(1-x^2)*u'+u^2-1];
+u0 = x; u = newton(N,u0);
+u(-1), u(1)
+norm(ϵ*u''+6*(1-x^2)*u'+u^2-1)
 ```

--- a/docs/src/usage/equations.md
+++ b/docs/src/usage/equations.md
@@ -14,9 +14,9 @@ where we want a solution that is periodic on ``[0,2π)``.  This can be solved su
 
 ```@repl using-pkgs
 b = Fun(cos,Fourier());
-c = 0.1; u = (𝒟+c*I)\b;
+c = 0.1; u = (𝒟+c*I) \ b;
 u(0.6)
-(c*cos(0.6)+sin(0.6))/(1+c^2)  # exact solution
+(c*cos(0.6)+sin(0.6)) / (1+c^2)  # exact solution
 ```
 
 Recall that `𝒟` is an alias to `Derivative() == Derivative(UnsetSpace(),1)`.
@@ -52,7 +52,7 @@ To pose this in ApproxFun, we want to find a `u` such that `Evaluation(0)*u == 1
 
 ```@repl using-pkgs
 t = Fun(0..1);
-u = [Evaluation(0); 𝒟 - t]  \ [1;0];
+u = [Evaluation(0); 𝒟-t] \ [1;0];
 u(0)
 norm(u'-t*u)
 ```
@@ -144,10 +144,10 @@ A = [B      0;
      0      B;
      𝒟^2-I  2I;
      I      𝒟+I];
-u,v = A\[0;0;0;exp(x);cos(x)];
+u,v = A \ [0;0;0;exp(x);cos(x)];
 u(-1),u'(-1),v(-1)
 norm(u''-u+2v-exp(x))
-norm(u + v'+v-cos(x))
+norm(u+v'+v-cos(x))
 ```
 
 In this example, the automatic space detection failed and so we needed to specify explicitly that the domain space for `B` is `Chebyshev()`.

--- a/docs/src/usage/equations.md
+++ b/docs/src/usage/equations.md
@@ -63,7 +63,7 @@ A common usage is two-point boundary value problems. Consider the singularly per
 
 ```math
 \begin{gathered}
-    ϵ \mathop{u}'' - x \mathop{u}' + \mathop{u} = \mathop{u}, \\
+    ϵ \mathop{u}'' - x \mathop{u}' + \mathop{u} = 0, \\
     \mathop{u}(-1) = 1, \mathop{u}(1) = 2.
 \end{gathered}
 ```

--- a/docs/src/usage/operators.md
+++ b/docs/src/usage/operators.md
@@ -1,413 +1,188 @@
-# Operators
-
-
-```@meta
-DocTestSetup = quote
-    using ApproxFun
-end
+```@setup using-pkgs
+using ApproxFun, LinearAlgebra
 ```
 
-Linear operators between two spaces in ApproxFun are represented by
-subtypes of `Operator`.  Every operator has a `domainspace` and `rangespace`.
-That is, if a `Fun` `f` has the space `domainspace(op)`, then`op*f` is a
-`Fun` with space `rangespace(op)`.
+# Operators
 
-Note that the size of an operator is specified by the dimension of the domain
-and range space.  
+Linear operators between two spaces in ApproxFun are represented by subtypes of `Operator`.  Every operator has a `domainspace` and `rangespace`.  That is, if a `Fun` `f` has the space `domainspace(op)`, then`op*f` is a `Fun` with space `rangespace(op)`.
+
+Note that the size of an operator is specified by the dimension of the domain and range space.  
 
 ## Calculus operators
 
-Differential and integral operators are perhaps the most useful type of operators
-in mathematics.  Consider the derivative operator on `CosSpace`:
-```jldoctest
-julia> D = Derivative(CosSpace())
-ConcreteDerivative:CosSpace(【0.0,6.283185307179586❫)→SinSpace(【0.0,6.283185307179586❫)
- 0.0  -1.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅    0.0  -2.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅     ⋅    0.0  -3.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅     ⋅     ⋅    0.0  -4.0    ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅    0.0  -5.0    ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅    0.0  -6.0    ⋅     ⋅     ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.0  -7.0    ⋅     ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.0  -8.0    ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.0  -9.0  ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.0  ⋱
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
+Differential and integral operators are perhaps the most useful type of operators in mathematics.  Consider the derivative operator on `CosSpace`:
 
-julia> f = Fun(θ->cos(cos(θ)), CosSpace());
-
-julia> fp = D*f;
-
-julia> fp(0.1) ≈ f'(0.1) ≈ sin(cos(0.1))*sin(0.1)
-true
+```@repl using-pkgs
+D = Derivative(CosSpace())
+f = Fun(θ->cos(cos(θ)), CosSpace());
+fp = D*f;
+fp(0.1) ≈ f'(0.1) ≈ sin(cos(0.1))*sin(0.1)
 ```
 
 Here, we specified the domain space for the derivative operator, and it automatically
 determined the range space:
 
-```@meta
-DocTestSetup = quote
-    using ApproxFun
-    D = Derivative(CosSpace())
-    f = Fun(θ->cos(cos(θ)),CosSpace())
-    fp = D*f
-end
+```@setup def-D
+using ApproxFun
+D = Derivative(CosSpace())
+f = Fun(θ->cos(cos(θ)),CosSpace())
+fp = D*f
 ```
 
-```jldoctest
-julia> rangespace(D) == space(fp) == SinSpace()
-true
+```@repl def-D
+rangespace(D) == space(fp) == SinSpace()
 ```
 
-Operators can be identified with infinite-dimensional matrices, whose entries
-are given by the canonical bases in the domain and range space.  In this case,
-the relevant formula is
-$$D \cos k \theta = -k \sin k \theta.$$
+Operators can be identified with infinite-dimensional matrices, whose entries are given by the canonical bases in the domain and range space.  In this case, the relevant formula is
+
+```math
+\mathop{D} \cos{kθ} = -k \sin{kθ}.
+```
+
 That is, the `(k,k+1)`th entry is as follows:
-```jldoctest
-julia> k,j = 5,6;
 
-julia> ej = Fun(domainspace(D),[zeros(j-1);1]);
-
-julia> D[k,j] ≈ (D*ej).coefficients[k] ≈ -k
-true
+```@repl def-D
+k,j = 5,6;
+ej = Fun(domainspace(D),[zeros(j-1);1]);
+D[k,j] ≈ (D*ej).coefficients[k] ≈ -k
 ```
 
-The `Chebyshev` space has the property that its derivatives are given by ultraspherical
-spaces:
-```jldoctest
-julia> Derivative(Chebyshev())
-ConcreteDerivative:Chebyshev(【-1.0,1.0】)→Ultraspherical(1,【-1.0,1.0】)
- ⋅  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅   3.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅   4.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅   5.0   ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅   6.0   ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   7.0   ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   8.0   ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   9.0  ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
+The `Chebyshev` space has the property that its derivatives are given by ultraspherical spaces:
+
+```@repl using-pkgs
+Derivative(Chebyshev())
 ```
 
 ## Functionals
 
-A particularly useful class of operators are _functionals_, which map
-from functions to scalar numbers.  These are represented by operators
-of size `1 × ∞`: that is, infinite-dimensional analogues of row vectors.
+A particularly useful class of operators are _functionals_, which map from functions to scalar numbers.  These are represented by operators of size `1 × ∞`: that is, infinite-dimensional analogues of row vectors.
 
-As an example, the evaluation functional `f(0)`
-on `CosSpace` has the form:
+As an example, the evaluation functional `f(0)` on `CosSpace` has the form:
 
-```jldoctest
-julia> B = Evaluation(CosSpace(),0)
-ConcreteEvaluation:CosSpace(【0.0,6.283185307179586❫)→ConstantSpace(Point(0))
- 1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  ⋯
-
-julia> B*f ≈ f(0)
-true
+```@repl using-pkgs
+B = Evaluation(CosSpace(),0)
+B*f ≈ f(0)
 ```
+
 As can be seen from the output, `rangespace(B)` is a `ConstantSpace(Point(0))`, a one-dimensional space used to represent scalars whose domain is a single point, `0`.
 
+Closely related to functionals are operators with finite-dimensional range.  For example, the `Dirichlet` operator represents the restriction of a space to its boundary.  In the case, of `Chebyshev()`, this amounts to evaluation at the endpoints `±1`:
 
-Closely related to functionals are operators with finite-dimensional range. For example,
-the `Dirichlet` operator represents the restriction of a space to its boundary.
-In the case, of `Chebyshev()`, this amounts to evaluation at the endpoints `±1`:
-```jldoctest
-julia> B = Dirichlet(Chebyshev())
-ConcreteDirichlet:Chebyshev(【-1.0,1.0】)→2-element ArraySpace:
- ConstantSpace(Point(-1.0))
- ConstantSpace(Point(1.0))
- 1.0  -1.0  1.0  -1.0  1.0  -1.0  1.0  -1.0  1.0  -1.0  ⋯
- 1.0   1.0  1.0   1.0  1.0   1.0  1.0   1.0  1.0   1.0  ⋯
-
-julia> size(B)
-(2, ∞)
-
-julia> B*Fun(exp)
-Fun(2-element ArraySpace:
- ConstantSpace(Point(-1.0))
- ConstantSpace(Point(1.0)) ,[0.367879, 2.71828])
-
-julia> B*Fun(exp) ≈ Fun([exp(-1),exp(1)])
-true
+```@repl using-pkgs
+B = Dirichlet(Chebyshev())
+size(B)
+B*Fun(exp)
+B*Fun(exp) ≈ Fun([exp(-1),exp(1)])
 ```
 
 ## Multiplication
 
 A `Multiplication` operator sends a `Fun` to a `Fun` in the corresponding space by multiplying a given function. The `Multiplication` operators are presented in matrix form in `ApproxFun`.
 
-```jldoctest
-julia> x = Fun();
-
-julia> M = Multiplication(1 + 2x + x^2, Chebyshev())
-ConcreteMultiplication:Chebyshev(【-1.0,1.0】)→Chebyshev(【-1.0,1.0】)
- 1.5  1.0   0.25   ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    ⋅
- 2.0  1.75  1.0   0.25   ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    ⋅
- 0.5  1.0   1.5   1.0   0.25   ⋅     ⋅     ⋅     ⋅     ⋅    ⋅
-  ⋅   0.25  1.0   1.5   1.0   0.25   ⋅     ⋅     ⋅     ⋅    ⋅
-  ⋅    ⋅    0.25  1.0   1.5   1.0   0.25   ⋅     ⋅     ⋅    ⋅
-  ⋅    ⋅     ⋅    0.25  1.0   1.5   1.0   0.25   ⋅     ⋅    ⋅
-  ⋅    ⋅     ⋅     ⋅    0.25  1.0   1.5   1.0   0.25   ⋅    ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅    0.25  1.0   1.5   1.0   0.25  ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅    0.25  1.0   1.5   1.0   ⋱
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.25  1.0   1.5   ⋱
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋱     ⋱    ⋱
-
-julia> (M * x).coefficients == ((1 + 2x + x^2) * x).coefficients == M[1:4,1:2] * x.coefficients
-true
+```@repl using-pkgs
+x = Fun();
+M = Multiplication(1 + 2x + x^2, Chebyshev())
+(M * x).coefficients == ((1 + 2x + x^2) * x).coefficients == M[1:4,1:2] * x.coefficients
 ```
 
 It is possible for domain space and range space to be different under `Mulitplication`.
 
-```jldoctest
-julia> c = Fun(θ -> cos(θ), CosSpace());
-
-julia> Multiplication(c, SinSpace())
-ConcreteMultiplication:SinSpace(【0.0,6.283185307179586❫)→SinSpace(【0.0,6.283185307179586❫)
- 8.974302782386682e-17  0.5                    …   ⋅                     ⋅
- 0.5                    8.974302782386682e-17      ⋅                     ⋅
-  ⋅                     0.5                        ⋅                     ⋅
-  ⋅                      ⋅                         ⋅                     ⋅
-  ⋅                      ⋅                         ⋅                     ⋅
-  ⋅                      ⋅                     …   ⋅                     ⋅
-  ⋅                      ⋅                         ⋅                     ⋅
-  ⋅                      ⋅                         ⋅                     ⋅
-  ⋅                      ⋅                        0.5                    ⋅
-  ⋅                      ⋅                        8.974302782386682e-17  ⋱
-  ⋅                      ⋅                     …   ⋱                     ⋱
+```@repl using-pkgs
+c = Fun(θ -> cos(θ), CosSpace());
+Multiplication(c, SinSpace())
 ```
 
 If a function is given by the expansion
-$$ f(\theta) = \sum_{n=1}^{\infty}  {f}_{n} * sin(n\theta) $$
+
+```math
+\mathop{f}(θ) = \sum_{n=1}^∞  f_n \sin{nθ}.
+```
 
 Then the matrix above can be easily derived from
-$$ cos(\theta) * f(\theta) = cos(\theta) \cdot (\sum_{n=1}^{\infty}  {f}_{n} \cdot sin(n\theta) $$
-$$ = \sum_{n=1}^{\infty}  {f}_{n} \cdot cos(\theta) \cdot sin(n\theta) $$
-$$ = \sum_{n=1}^{\infty}  {f}_{n} \cdot 0.5 \cdot ((sin(n-1)\theta) + (sin(n+1)\theta) $$
-$$ = \sum_{n=1}^{\infty}  0.5 \cdot ({f}_{n-1} + {f}_{n+1}) \cdot sin(n\theta) $$.
+
+```math
+\begin{aligned}
+\cos{θ} \mathop{f}(θ) &= \cos{θ} \sum_{n=1}^∞ f_n \sin{nθ} \\
+                          &= \sum_{n=1}^∞ f_n \cos{θ} \sin{nθ} \\
+                          &= \sum_{n=1}^∞ \frac{1}{2} f_n \left(\sin{(n-1)θ} + \sin{(n+1)θ}\right) \\
+                          &= \sum_{n=1}^∞ \frac{1}{2} \left(f_{n-1} + f_{n+1}\right) \sin{nθ},
+\end{aligned}
+```
+
+where ``f_0 = 0``.
 
 ## Algebraic manipulation of operators
 
-Operators can be algebraically manipulated, provided that the domain and
-range spaces are compatible, or can be made compatible.  
-As a simple example, we can add the second derivative of a Fourier space to the
+Operators can be algebraically manipulated, provided that the domain and range spaces are compatible, or can be made compatible.  As a simple example, we can add the second derivative of a Fourier space to the
 identity operator:
-```jldoctest
-julia> D2 = Derivative(Fourier(),2)
-DerivativeWrapper:Fourier(【0.0,6.283185307179586❫)→Fourier(【0.0,6.283185307179586❫)
- 0.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅   -1.0    ⋅     ⋅     ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅     ⋅   -1.0    ⋅     ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅     ⋅     ⋅   -4.0    ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅   -4.0    ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅   -9.0    ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   -9.0     ⋅      ⋅      ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   -16.0     ⋅      ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅      ⋅   -16.0     ⋅   ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅      ⋅      ⋅   -25.0  ⋅
-  ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋱
 
-julia> D2 + I
-PlusOperator:Fourier(【0.0,6.283185307179586❫)→Fourier(【0.0,6.283185307179586❫)
- 1.0   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅   0.0   ⋅     ⋅     ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅    ⋅   0.0    ⋅     ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅    ⋅    ⋅   -3.0    ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅    ⋅    ⋅     ⋅   -3.0    ⋅     ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅    ⋅    ⋅     ⋅     ⋅   -8.0    ⋅      ⋅      ⋅      ⋅   ⋅
-  ⋅    ⋅    ⋅     ⋅     ⋅     ⋅   -8.0     ⋅      ⋅      ⋅   ⋅
-  ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅   -15.0     ⋅      ⋅   ⋅
-  ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅      ⋅   -15.0     ⋅   ⋅
-  ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅      ⋅      ⋅   -24.0  ⋅
-  ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅      ⋅      ⋅      ⋅   ⋱
+```@repl using-pkgs
+D2 = Derivative(Fourier(),2)
+D2 + I
 ```
 
-When the domain and range space are not the same, the identity operator
-becomes a conversion operator.  That is, to represent `D+I` acting on the Chebyshev
-space, we would do the following:
+When the domain and range space are not the same, the identity operator becomes a conversion operator.  That is, to represent `D+I` acting on the Chebyshev space, we would do the following:
 
-```jldoctest
-julia> D = Derivative(Chebyshev())
-ConcreteDerivative:Chebyshev(【-1.0,1.0】)→Ultraspherical(1,【-1.0,1.0】)
- ⋅  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅   3.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅   4.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅   5.0   ⋅    ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅   6.0   ⋅    ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   7.0   ⋅    ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   8.0   ⋅   ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   9.0  ⋅
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
- ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
-
-julia> C = Conversion(Chebyshev(),Ultraspherical(1))
-ConcreteConversion:Chebyshev(【-1.0,1.0】)→Ultraspherical(1,【-1.0,1.0】)
- 1.0  0.0  -0.5    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅   0.5   0.0  -0.5    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅    0.5   0.0  -0.5    ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅     ⋅    0.5   0.0  -0.5    ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅     ⋅     ⋅    0.5   0.0  -0.5    ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅    0.5   0.0  -0.5    ⋅     ⋅   ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅    0.5   0.0  -0.5    ⋅   ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.5   0.0  -0.5  ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.5   0.0  ⋱
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.5  ⋱
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
-
-
-julia> D + C
-PlusOperator:Chebyshev(【-1.0,1.0】)→Ultraspherical(1,【-1.0,1.0】)
- 1.0  1.0  -0.5    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅   0.5   2.0  -0.5    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅    0.5   3.0  -0.5    ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅     ⋅    0.5   4.0  -0.5    ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅     ⋅     ⋅    0.5   5.0  -0.5    ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅    0.5   6.0  -0.5    ⋅     ⋅   ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅    0.5   7.0  -0.5    ⋅   ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.5   8.0  -0.5  ⋅
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.5   9.0  ⋱
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.5  ⋱
-  ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
+```@repl using-pkgs
+D = Derivative(Chebyshev())
+C = Conversion(Chebyshev(),Ultraspherical(1))
+D + C
 ```
 
-ApproxFun can automatically determine the spaces, so if one writes
-`D + I` it will translate it to `D + C`.  
-
+ApproxFun can automatically determine the spaces, so if one writes `D + I` it will translate it to `D + C`.  
 
 Now consider the Fredholm integral operator of the second kind:
 
-$$L u = u + {\rm e}^x \int_{-1}^1 u(x) {\rm d}x$$
+```math
+\mathop{L} \mathop{u} = \mathop{u} + \mathop{e}^x \int_{-1}^1 \mathop{u}(x) \mathop{dx}.
+```
 
 We can construct this using
 
-```jldoctest
-julia> x = Fun();
-
-julia> Σ = DefiniteIntegral(Chebyshev())
-ConcreteDefiniteIntegral:Chebyshev(【-1.0,1.0】)→ConstantSpace
- 2.0  0.0  -0.6666666666666666  0.0  …  0.0  -0.031746031746031744  0.0  ⋯
-
-julia> L = I + exp(x)*Σ
-LowRankPertOperator:Chebyshev(【-1.0,1.0】)→Chebyshev(【-1.0,1.0】)
- 3.5321317555040164     0.0  …  -0.0401925675476828      0.0  ⋯
- 2.260636415969941      1.0     -0.03588311771380859     0.0  ⋱
- 0.5429906790681531     0.0     -0.008618899667748462    0.0  ⋱
- 0.08867369969732766    0.0     -0.0014075190428147247   0.0  ⋱
- 0.010948480884187475   0.0     -0.00017378541086011864  0.0  ⋱
- 0.001085852623827888   0.0  …  -1.7235755933775998e-5   0.0  ⋱
- 8.995464590859038e-5   0.0     -1.4278515223585775e-6   0.0  ⋱
- 6.396872924803984e-6   0.0     -1.015376654730791e-7    0.0  ⋱
- 3.9842496133455937e-7  0.0      0.9999999936757943      0.0  ⋱
- 2.20735434510347e-8    0.0     -3.503737055719794e-10   1.0  ⋱
-  ⋮                      ⋱   …    ⋱                       ⋱   ⋱
-
-julia> u = cos(10x^2);
-
-julia> (L*u)(0.1)
-1.3777980523127336
-
-julia> u(0.1) + exp(0.1)*sum(u)
-1.3777980523127336
+```@repl using-pkgs
+x = Fun();
+Σ = DefiniteIntegral(Chebyshev())
+L = I + exp(x)*Σ
+u = cos(10x^2);
+(L*u)(0.1)
+u(0.1) + exp(0.1)*sum(u)
 ```
 
-Note that `DefiniteIntegral` is a functional, i.e., a 1 × ∞ operator.  when
-multiplied on the left by a function, it automatically constructs the operator
-${\rm e}^x \int_{-1}^1 f(x) dx$
-via
+Note that `DefiniteIntegral` is a functional, i.e., a 1 × ∞ operator.  when multiplied on the left by a function, it automatically constructs the operator ``\mathop{e}^x \int_{-1}^1 \mathop{f}(x) \mathop{dx}`` via
 
-```@meta
-DocTestSetup = quote
-    using ApproxFun
-    x = Fun()
-    Q = DefiniteIntegral(Chebyshev())
-end
+```@setup def-Σ
+using ApproxFun
+x = Fun()
+Σ = DefiniteIntegral(Chebyshev())
 ```
 
-```jldoctest
-julia> M = Multiplication(exp(x),ConstantSpace())
-ConcreteMultiplication:ConstantSpace→Chebyshev(【-1.0,1.0】)
- 1.26607    
- 1.13032    
- 0.271495   
- 0.0443368  
- 0.00547424
- 0.000542926
- 4.49773e-5
- 3.19844e-6
- 1.99212e-7
- 1.10368e-8
-  ⋮         
-
-julia> M*Σ
-TimesOperator:Chebyshev(【-1.0,1.0】)→Chebyshev(【-1.0,1.0】)
- 2.53213     0.0  -0.844044     0.0  …  0.0  -0.0401926    0.0  ⋯
- 2.26064     0.0  -0.753545     0.0     0.0  -0.0358831    0.0  ⋱
- 0.542991    0.0  -0.180997     0.0     0.0  -0.0086189    0.0  ⋱
- 0.0886737   0.0  -0.0295579    0.0     0.0  -0.00140752   0.0  ⋱
- 0.0109485   0.0  -0.00364949   0.0     0.0  -0.000173785  0.0  ⋱
- 0.00108585  0.0  -0.000361951  0.0  …  0.0  -1.72358e-5   0.0  ⋱
- 8.99546e-5  0.0  -2.99849e-5   0.0     0.0  -1.42785e-6   0.0  ⋱
- 6.39687e-6  0.0  -2.13229e-6   0.0     0.0  -1.01538e-7   0.0  ⋱
- 3.98425e-7  0.0  -1.32808e-7   0.0     0.0  -6.32421e-9   0.0  ⋱
- 2.20735e-8  0.0  -7.35785e-9   0.0     0.0  -3.50374e-10  0.0  ⋱
-  ⋮           ⋱     ⋱            ⋱   …   ⋱     ⋱            ⋱   ⋱
+```@repl def-Σ
+M = Multiplication(exp(x),ConstantSpace())
+M*Σ
 ```
-Note that `Q*exp(x)` applies the operator to a function.  To construct the operator that first multiplies by `exp(x)`, use `Q[exp(x)]`.  This is equivalent to `Q*Multiplication(exp(x),Chebyshev())`.
 
+Note that `Σ*exp(x)` applies the operator to a function.  To construct the operator that first multiplies by `exp(x)`, use `Σ[exp(x)]`.  This is equivalent to `Σ*Multiplication(exp(x),Chebyshev())`.
 
 ## Operators and space promotion
 
-It is often more convenient to not specify a space explicitly, but rather
-infer it when the operator is used.  For example, we can construct `Derivative()`,
-which has the alias `𝒟`, and represents the first derivative on any space:
-```jldoctest
-julia> f = Fun(cos,Chebyshev(0..1)); (𝒟*f)(0.1)
--0.09983341664681705
+It is often more convenient to not specify a space explicitly, but rather infer it when the operator is used.  For example, we can construct `Derivative()`, which has the alias `𝒟`, and represents the first derivative on any space:
 
-julia> f = Fun(cos,Fourier()); (𝒟*f)(0.1)
--0.09983341664682804
-```
-Behind the scenes, `Derivative()` is equivalent to `Derivative(UnsetSpace(),1)`.
-When multiplying a function `f`, the domain space is promoted before multiplying,
-that is, `Derivative()*f` is equivalent to `Derivative(space(f))*f`.  
-
-This promotion of the domain space happens even when operators have spaces attached.
-This facilitates the following construction:
-```jldoctest
-julia> D = Derivative(Chebyshev());
-
-julia> D^2
-ConcreteDerivative:Chebyshev(【-1.0,1.0】)→Ultraspherical(2,【-1.0,1.0】)
- ⋅  ⋅  4.0   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
- ⋅  ⋅   ⋅   6.0   ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
- ⋅  ⋅   ⋅    ⋅   8.0    ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
- ⋅  ⋅   ⋅    ⋅    ⋅   10.0    ⋅     ⋅     ⋅     ⋅   ⋅
- ⋅  ⋅   ⋅    ⋅    ⋅     ⋅   12.0    ⋅     ⋅     ⋅   ⋅
- ⋅  ⋅   ⋅    ⋅    ⋅     ⋅     ⋅   14.0    ⋅     ⋅   ⋅
- ⋅  ⋅   ⋅    ⋅    ⋅     ⋅     ⋅     ⋅   16.0    ⋅   ⋅
- ⋅  ⋅   ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅   18.0  ⋅
- ⋅  ⋅   ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
- ⋅  ⋅   ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
- ⋅  ⋅   ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
-```
-Note that `rangespace(D) ≠ Chebyshev()`, hence the operators are not compatible.
-Therefore, it has thrown away its domain space, and thus this is equivalent to
-`Derivative(rangespace(D))*D`.
-
-
-
-
-
-```@meta
-DocTestSetup = nothing
+```@repl using-pkgs
+f = Fun(cos,Chebyshev(0..1)); (𝒟*f)(0.1)
+f = Fun(cos,Fourier()); (𝒟*f)(0.1)
 ```
 
+Behind the scenes, `Derivative()` is equivalent to `Derivative(UnsetSpace(),1)`.  When multiplying a function `f`, the domain space is promoted before multiplying, that is, `Derivative()*f` is equivalent to `Derivative(space(f))*f`.  
+
+This promotion of the domain space happens even when operators have spaces attached.  This facilitates the following construction:
+
+```@repl using-pkgs
+D = Derivative(Chebyshev());
+D^2
+```
+
+Note that `rangespace(D) ≠ Chebyshev()`, hence the operators are not compatible.  Therefore, it has thrown away its domain space, and thus this is equivalent to `Derivative(rangespace(D))*D`.
 
 ## Concatenating operators
 
-The concatenation functions `vcat`, `hcat` and `hvcat` are overriden for
-operators to represent the resulting combined operator, now with
-a `rangespace` or `domainspace` that is an `ArraySpace`.
+The concatenation functions `vcat`, `hcat` and `hvcat` are overriden for operators to represent the resulting combined operator, now with a `rangespace` or `domainspace` that is an `ArraySpace`.

--- a/docs/src/usage/spaces.md
+++ b/docs/src/usage/spaces.md
@@ -122,8 +122,8 @@ Some spaces are built out of other spaces:
 
 ### `JacobiWeight`
 
-`JacobiWeight(β,α,space)`  weights `space`, which is typically `Chebyshev()` or `Jacobi(b,a)`, by a Jacobi weight `(1+x)^α*(1-x)^β`: in other words, if the basis for `space` is ``\mathop{ψ}_k(x)`` and the domain is the unit interval `-1 .. 1`, then the basis for `JacobiWeight(β,α,space)` is ``(1+x)^α(1-x)^β \mathop{ψ}_k(x)``. If the domain is
-not the unit interval, then the basis is determined by mapping back to the unit interval: that is, if ``\mathop{M}(x)`` is the map dictated by `tocanonical(space, x)`, where the canonical domain is the unit interval, then the basis is ``(1+\mathop{M}(x))^α(1-\mathop{M}(x))^β \mathop{ψ}_k(x)``. For example, if the domain is another interval `a .. b`, then
+`JacobiWeight(β,α,space)`  weights `space`, which is typically `Chebyshev()` or `Jacobi(b,a)`, by a Jacobi weight `(1+x)^α*(1-x)^β`: in other words, if the basis for `space` is ``\mathop{ψ}_k(x)`` and the domain is the unit interval `-1..1`, then the basis for `JacobiWeight(β,α,space)` is ``(1+x)^α(1-x)^β \mathop{ψ}_k(x)``. If the domain is
+not the unit interval, then the basis is determined by mapping back to the unit interval: that is, if ``\mathop{M}(x)`` is the map dictated by `tocanonical(space, x)`, where the canonical domain is the unit interval, then the basis is ``(1+\mathop{M}(x))^α(1-\mathop{M}(x))^β \mathop{ψ}_k(x)``. For example, if the domain is another interval `a..b`, then
 
 ```math
 \mathop{M}(x) = \frac{2x-b-a}{b-a},

--- a/docs/src/usage/spaces.md
+++ b/docs/src/usage/spaces.md
@@ -1,139 +1,120 @@
+```@setup using-pkgs
+using ApproxFun, LinearAlgebra
+```
+
 # Spaces
 
-A `Space` is an abstract type whose subtypes indicate which space a function lives in.
-This typically corresponds to the span of a (possibly infinite) basis.
+A `Space` is an abstract type whose subtypes indicate which space a function lives in. This typically corresponds to the span of a (possibly infinite) basis.
 
 ## Classical orthogonal polynomial spaces
 
-`Chebyshev`, `Ultraspherical`, `Jacobi`, `Hermite`, and `Laguerre` are spaces
-corresponding to expansion in classical orthogonal polynomials.
+`Chebyshev`, `Ultraspherical`, `Jacobi`, `Hermite`, and `Laguerre` are spaces corresponding to expansion in classical orthogonal polynomials.
 
-Note that we always use the classical normalization: the basis are _not_ orthonormal.
-This is because this normalization leads to rational recurrence relationships,
-which are more efficient than their normalized counterparts. See
-the [Digital Library of Mathematical Functions](https://dlmf.nist.gov/18) for
-more information.
-
+Note that we always use the classical normalization: the basis are _not_ orthonormal.  This is because this normalization leads to rational recurrence relationships, which are more efficient than their normalized counterparts. See the [Digital Library of Mathematical Functions](https://dlmf.nist.gov/18) for more information.
 
 ### Chebyshev space
 
-The default space in ApproxFun is `Chebyshev`, which represents expansions
-in Chebyshev polynomials:
+The default space in ApproxFun is `Chebyshev`, which represents expansions in Chebyshev polynomials:
 
-$$f(x) = \sum_{k=0}^\infty f_k T_k(x)$$
+```math
+\mathop{f}(x) = \sum_{k=0}^∞ f_k \mathop{T}_k(x),
+```
 
-where $T_k(x) = \cos k \,{\rm acos} x$, which are orthogonal polynomials
-with respect to the weight
-$$
-{1 \over \sqrt{1-x^2}} \qquad\hbox{for}\qquad -1 \leq x \leq 1.
-$$
+where ``\mathop{T}_k(x) = \cos(k\arccos{x})``, which are orthogonal polynomials with respect to the weight
+
+```math
+\frac{1}{\sqrt{1-x^2}} \quad\text{for}\quad -1 ≤ x ≤ 1.
+```
+
 Note that there is an intrinsic link between `Chebyshev` and `CosSpace`:  
 
-$$g(\theta) = f(\cos \theta) = \sum_{k=0}^\infty f_k \cos k \theta$$
+```math
+\mathop{g}(θ) = \mathop{f}(\cos{θ}) = \sum_{k=0}^∞ f_k \cos{kθ}.
+```
 
 In other words:
-```@meta
-DocTestSetup = quote
-    using ApproxFun
-end
-```
-```jldoctest
-julia> f=Fun(exp,Chebyshev());
 
-julia> g=Fun(CosSpace(),f.coefficients); # specify the coefficients directly
-
-julia> f(cos(0.1))
-2.70473560723178
-
-julia> g(0.1)
-2.7047356072317794
+```@repl using-pkgs
+f = Fun(exp,Chebyshev());
+g = Fun(CosSpace(),f.coefficients);  # specify the coefficients directly
+f(cos(0.1))
+g(0.1)
 ```
 
 ### Ultraspherical spaces
 
-A key tool for solving differential equations are the ultraspherical spaces,
-encoded as `Ultraspherical(λ)` for `λ ≠ 0`,
-which can be defined by the span of derivatives of Chebyshev polynomials, or alternatively
-as polynomials orthogonal with respect to the weight
-$$
-(1-x^2)^{\lambda - 1/2} \qquad\hbox{for}\qquad -1 \leq x \leq 1.
-$$
+A key tool for solving differential equations are the ultraspherical spaces, encoded as `Ultraspherical(λ)` for `λ ≠ 0`,
+which can be defined by the span of derivatives of Chebyshev polynomials, or alternatively as polynomials orthogonal with respect to the weight ``(1-x^2)^{λ - \frac{1}{2}}`` for ``-1 ≤ x ≤ 1``.
 
-Note that `Ultraspherical(1)` corresponds to the Chebyshev basis of the
-second kind: $U_k(x) = {\sin (k+1) {\rm acos} x \over \sin {\rm acos} x}$.  
-The relationship with Chebyshev polynomials follows from trigonemetric
-identities: $T_k'(x) = k U_{k-1}(x)$.  
+Note that `Ultraspherical(1)` corresponds to the Chebyshev basis of the second kind: ``\mathop{U}_k(x) = \frac{\sin((k+1)\arccos{x})}{\sin(\arccos{x})}``.  The relationship with Chebyshev polynomials follows from trigonemetric identities: ``\mathop{T}_k'(x) = k \mathop{U}_{k-1}(x)``.  
 
-Converting between ultraspherical polynomials (with integer orders) is
-extremely efficient: it requires $O(n)$ operations, where $n$ is the number of coefficients.
+Converting between ultraspherical polynomials (with integer orders) is extremely efficient: it requires ``\mathop{O}(n)`` operations, where ``n`` is the number of coefficients.
 
 ### Jacobi spaces
 
-`Jacobi(b,a)` represents the space spanned by the Jacobi polynomials, which
-are orthogonal polynomials with respect to the weight
-$$
-(1+x)^b(1-x)^a
-$$
-using the standard normalization.
+`Jacobi(b,a)` represents the space spanned by the Jacobi polynomials, which are orthogonal polynomials with respect to the weight
 
+```math
+(1+x)^b(1-x)^a
+```
+
+using the standard normalization.
 
 ## Fourier and Laurent spaces
 
-There are several different spaces to represent functions on periodic domains,
-which are typically a `PeriodicSegment`, `Circle` or `PeriodicLine`.  
+There are several different spaces to represent functions on periodic domains, which are typically a `PeriodicSegment`, `Circle` or `PeriodicLine`.  
 
 `CosSpace` represents expansion in cosine series:
 
-$$f(\theta) = \sum_{k=0}^\infty f_k \cos k \theta$$
+```math
+\mathop{f}(θ) = \sum_{k=0}^∞ f_k \cos{kθ}.
+```
 
 `SinSpace` represents expansion in sine series:
 
-$$f(\theta) = \sum_{k=0}^\infty f_k \sin (k+1) \theta$$
+```math
+\mathop{f}(θ) = \sum_{k=0}^∞ f_k \sin{(k+1)θ}.
+```
+
+`Fourier` represents functions that are sums of sines and cosines.  Note that if a function has the form
+
+```math
+\mathop{f}(θ) = f_0 + \sum_{k=1}^∞ \left(f_k^\mathrm{s} \sin{kθ} + f_k^\mathrm{c} \cos{kθ}\right),
+```
+
+then the coefficients of the resulting `Fun` are ordered as ``[f_0, f_1^\mathrm{s}, f_1^\mathrm{c}, …]``.  For example:
+
+```@repl using-pkgs
+f = Fun(Fourier(),[1,2,3,4]);
+f(0.1)
+1 + 2sin(0.1) + 3cos(0.1) + 4sin(2*0.1)
+```
 
 `Taylor` represents expansion with only non-negative complex exponential terms:
 
-$$f(\theta) = \sum_{k=0}^\infty f_k {\rm e}^{{\rm i} k \theta}$$
+```math
+\mathop{f}(θ) = \sum_{k=0}^∞ f_k \mathop{e}^{ikθ}.
+```
 
 `Hardy{false}` represents expansion with only negative complex exponential terms:
 
-$$f(\theta) = \sum_{k=0}^\infty f_k {\rm e}^{-{\rm i} (k+1) \theta}$$
-
-`Fourier` represents functions that are sums of sines and cosines.  Note that
-if a function has the form
-
-$$f(\theta) = f_0 + \sum_{k=1}^\infty f_k^{\rm c} \cos k \theta + f_k^{\rm s} \sin k\theta$$
-
-then the coefficients of the resulting `Fun` are order as $[f_0,f_1^{\rm s},f_1^{\rm c},…]$.
-For example:
-
-```jldoctest
-julia> f = Fun(Fourier(),[1,2,3,4]);
-
-julia> f(0.1)
-4.979356652307978
-
-julia> 1 + 2sin(0.1) + 3cos(0.1) + 4sin(2*0.1)
-4.979356652307979
+```math
+\mathop{f}(θ) = \sum_{k=0}^∞ f_k \mathop{e}^{-i(k+1)θ}.
 ```
 
-`Laurent` represents functions that are sums of complex exponentials.  Note that
-if a function has the form
+`Laurent` represents functions that are sums of complex exponentials.  Note that if a function has the form
 
-$$f(\theta) = \sum_{k=-\infty}^\infty f_k {\rm e}^{{\rm i} k \theta}$$
-
-then the coefficients of the resulting `Fun` are order as $[f_0,f_{-1},f_1,…]$.
-For example:
-
-```jldoctest
-julia> f = Fun(Laurent(),[1,2,3,4]);
-
-julia> f(0.1)
-9.895287137755096 - 0.694843906533417im
-
-julia> 1 + 2exp(-im*0.1) + 3exp(im*0.1) + 4exp(-2im*0.1)
-9.895287137755094 - 0.6948439065334167im
+```math
+\mathop{f}(θ) = \sum_{k=-∞}^∞ f_k \mathop{e}^{ikθ},
 ```
 
+then the coefficients of the resulting `Fun` are order as ``[f_0, f_{-1}, f_1, …]``.  For example:
+
+```@repl using-pkgs
+f = Fun(Laurent(),[1,2,3,4]);
+f(0.1)
+1 + 2exp(-im*0.1) + 3exp(im*0.1) + 4exp(-2im*0.1)
+```
 
 ## Modifier spaces
 
@@ -141,126 +122,59 @@ Some spaces are built out of other spaces:
 
 ### `JacobiWeight`
 
- `JacobiWeight(β,α,space)`  weights `space`, which is typically `Chebyshev()` or `Jacobi(b,a)`,
- by a Jacobi weight `(1+x)^α*(1-x)^β`: in other words, if the basis for
-`space` is $\psi_k(x)$ and the domain is the unit interval `-1 .. 1`, then the basis for
-`JacobiWeight(β,α,space)` is $(1+x)^α(1-x)^β \psi_k(x)$. If the domain is
-not the unit interval, then the basis is determined by mapping back to the
-unit interval: that is, if $M(x)$ is the map dictated by `tocanonical(space, x)`,
-where the canonical domain is the unit interval,
-then the basis is $(1+M(x))^α(1-M(x))^β \psi_k(x)$. For example, if the domain is another
-interval `a .. b`, then
-$$
-M(x) = {2x-b-a \over b-a}
-$$
+`JacobiWeight(β,α,space)`  weights `space`, which is typically `Chebyshev()` or `Jacobi(b,a)`, by a Jacobi weight `(1+x)^α*(1-x)^β`: in other words, if the basis for `space` is ``\mathop{ψ}_k(x)`` and the domain is the unit interval `-1 .. 1`, then the basis for `JacobiWeight(β,α,space)` is ``(1+x)^α(1-x)^β \mathop{ψ}_k(x)``. If the domain is
+not the unit interval, then the basis is determined by mapping back to the unit interval: that is, if ``\mathop{M}(x)`` is the map dictated by `tocanonical(space, x)`, where the canonical domain is the unit interval, then the basis is ``(1+\mathop{M}(x))^α(1-\mathop{M}(x))^β \mathop{ψ}_k(x)``. For example, if the domain is another interval `a .. b`, then
+
+```math
+\mathop{M}(x) = \frac{2x-b-a}{b-a},
+```
+
 and the basis becomes
-$$
-\left({2 \over (b-a)}\right)^{\alpha+\eta}  (x-a)^α(b-x)^β \psi_k(x)
-$$
+
+```math
+\left(\frac{2}{b-a}\right)^{α+β}  (x-a)^α (b-x)^β \mathop{ψ}_k(x).
+```
 
 ### `SumSpace`
 
-`SumSpace((space_1,space_2,…,space_n))` represents the direct sum of the spaces,
-where evaluation is defined by adding up each component. A simple example is the
-following, showing that the coefficients are stored by interlacing:
-```jldoctest
-julia> x = Fun(identity,-1..1);
+`SumSpace((space_1,space_2,…,space_n))` represents the direct sum of the spaces, where evaluation is defined by adding up each component. A simple example is the following, showing that the coefficients are stored by interlacing:
 
-julia> f = cos(x-0.1)*sqrt(1-x^2) + exp(x);
-
-julia> space(f) # isa SumSpace
-(1-x^2)^0.5[Chebyshev(【-1.0,1.0】)]⊕Chebyshev(【-1.0,1.0】)
-
-julia> a, b = components(f);
-
-julia> a(0.2) # cos(0.2-0.1)*sqrt(1-0.2^2)
-0.9749009987500246
-
-julia> b(0.2) # exp(0.2)
-1.2214027581601699
-
-julia> f(0.2) # a(0.2) + b(0.2)
-2.1963037569101944
-
-julia> norm(f.coefficients[1:2:end] - a.coefficients)
-0.0
-
-julia> norm(f.coefficients[2:2:end] - b.coefficients)
-0.0
+```@repl using-pkgs
+x = Fun(identity,-1..1);
+f = cos(x-0.1)*sqrt(1-x^2) + exp(x);
+space(f)  # isa SumSpace
+a, b = components(f);
+a(0.2)  # cos(0.2-0.1)*sqrt(1-0.2^2)
+b(0.2)  # exp(0.2)
+f(0.2)  # a(0.2) + b(0.2)
+norm(f.coefficients[1:2:end] - a.coefficients)
+norm(f.coefficients[2:2:end] - b.coefficients)
 ```
-More complicated examples may interlace the coefficients using a different strategy.
-Note that it is difficult to represent the first component of function $f$ by a Chebyshev series because the derivatives of $f$ at its boundaries blow up, whereas the derivative of a polynomial is a polynomial.
 
-Note that `Fourier` and `Laurent` are currently implemented as `SumSpace`, but this
-may change in the future.
+More complicated examples may interlace the coefficients using a different strategy.  Note that it is difficult to represent the first component of function ``\mathop{f}`` by a Chebyshev series because the derivatives of ``\mathop{f}`` at its boundaries blow up, whereas the derivative of a polynomial is a polynomial.
 
-### `PiecewiseSpace`
-
-`PiecewiseSpace((space_1,space_2,…,space_n))` represents the direct sum of the spaces,
-where evaluation is defined in a piecewise way. A simple example is the
-following:
-```jldoctest
-julia> x = Fun(Domain(-1 .. 0) ∪ Domain( 1 .. 2));
-
-julia> f = exp(x);
-
-julia> a, b = components(f);
-
-julia> f(-0.5) - a(-0.5)
-0.0
-
-julia> f(1.5) - b(1.5)
-0.0
-
-julia> f(0.5) # outside domain components
-0.0
-
-julia> norm(f.coefficients[2:2:end] - b.coefficients)
-0.0
-
-julia> norm(f.coefficients[1:2:end] - a.coefficients)
-0.0
-```
-More complicated examples may interlace the coefficients using a different strategy.
+Note that `Fourier` and `Laurent` are currently implemented as `SumSpace`, but this may change in the future.
 
 ### `ArraySpace`
 
-`ArraySpace(::Array{<:Space})` represents the direct sum of the spaces,
-where evaluation is defined in an array-wise manner. A simple example is the
-following:
-```jldoctest
-julia> x = Fun(identity,-1..1);
+`ArraySpace(::Array{<:Space})` represents the direct sum of the spaces, where evaluation is defined in an array-wise manner.  A simple example is the following:
 
-julia> f = [exp(x); sqrt(1-x^2)*cos(x-0.1)];
-
-julia> space(f)
-2-element ArraySpace:
- Chebyshev(【-1.0,1.0】)             
- (1-x^2)^0.5[Chebyshev(【-1.0,1.0】)]
-
-julia> a, b = components(f);
-
-julia> norm(f(0.5) - [a(0.5); b(0.5)])
-0.0
-
-julia> norm(f.coefficients[1:2:end] - a.coefficients)
-0.0
-
-julia> norm(f.coefficients[2:2:end] - b.coefficients)
-0.0
+```@repl using-pkgs
+x = Fun(identity, -1..1);
+f = [exp(x); sqrt(1-x^2)*cos(x-0.1)];
+space(f)
+a, b = components(f);
+norm(f(0.5) - [a(0.5); b(0.5)])
+norm(f.coefficients[1:2:end] - a.coefficients)
+norm(f.coefficients[2:2:end] - b.coefficients)
 ```
-More complicated examples may interlace the coefficients using a different strategy.
 
+More complicated examples may interlace the coefficients using a different strategy.
 
 ### `TensorSpace`
 
-`TensorSpace((space_1,space_2))` represents the tensor product of two spaces.
-See documentation of `TensorSpace` for more details on how the coefficients
-are interlaced. Note that more than two spaces is only partially supported.
-
-
+`TensorSpace((space_1,space_2))` represents the tensor product of two spaces.  See documentation of `TensorSpace` for more details on how the coefficients are interlaced. Note that more than two spaces is only partially supported.
 
 ## Unset space
 
-`UnsetSpace` is a special space that is used as a stand in when a
-space has not yet been determined, particularly by operators.  
+`UnsetSpace` is a special space that is used as a stand in when a space has not yet been determined, particularly by operators.  


### PR DESCRIPTION
This PR applies the up-to-date recommendations of `Documenter.jl` to the documentation of `ApproxFun`.  (It does not change the contents of the documentation, except for bugs.)  This PR potentially fixes https://github.com/JuliaApproximation/ApproxFun.jl/issues/756.

Here are some of the key changes:

### Bug fixes
- Match the order of the items in Contents of `docs/index.md` with the sidebar`s.
- Remove the section about `PiecewiseSpace`, because the union of disjoint domains is not supported; see [this issue](https://github.com/JuliaApproximation/DomainSets.jl/issues/40).

### Code examples
- Use ` ```@repl``` ` to avoid outdated outputs of code examples and automatically generate up-to-date outputs; see [this item](https://juliadocs.github.io/Documenter.jl/stable/man/syntax/#@repl-block) in `Documenter.jl`'s documentation.
- Use ` ```julia-repl` instead of ` ```julia` for REPL examples.

### LaTeX
- Use ` ``...`` ` and ` ```math ` instead of the deprecated `$...$` and `$$...$$`; see Warning in [this section](https://juliadocs.github.io/Documenter.jl/stable/man/latex/#Inline-Equations) of `Documenter.jl`'s documentation.
- Use Unicode characters (e.g., `θ`, `π`, `∞`) instead of LaTeX escape sequences (e.g., `\theta`, `\pi`, `\infty`); see Item 7 in [this section](https://docs.julialang.org/en/v1/manual/documentation/#man-documentation) of the Julia documentation.
- Use the registered LaTeX escape sequence `\arccos` instead of `\rm acos`.
- Surround function names by `\mathop{...}`; this renders the product of two functions with an appropriate space between them (e.g., the rendering of `\mathop{T}_i(x) \mathop{T}_j(x)` puts a space between Tᵢ(x) and Tⱼ(x)).