### PR TITLE
Export ∆ (\increment) and ∑ (\sum) for Laplacian() and sum()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,8 +35,10 @@ SpecialFunctions = "1.1, 2"
 julia = "1.6"
 
 [extras]
+DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["DualNumbers", "Random", "SpecialFunctions", "Test"]

--- a/src/Extras/poetry.jl
+++ b/src/Extras/poetry.jl
@@ -43,9 +43,9 @@ cross(∇::Function,F::Vector{M}) where {M<:MultivariateFun} = curl(F)
 
 ## Domains
 
-const 𝕀 = ChebyshevInterval()
-const ℝ = Line()
-const 𝕌 = Circle()
+const 𝕀 = ChebyshevInterval()  # \bbI<tab>
+const ℝ = Line()  # \bbR<tab>
+const 𝕌 = Circle()  # \bbU<tab>
 
-𝒟 = Derivative()
-∆ = Laplacian()
+𝒟 = Derivative()  # \scrD<tab>
+∆ = Laplacian()  # \increment<tab>, not \Delta<tab>

--- a/src/Extras/poetry.jl
+++ b/src/Extras/poetry.jl
@@ -3,7 +3,7 @@
 #####
 
 
-export chebyshevt, chebyshevu, legendre, ∫, ⨜, ⨍, ChebyshevWeight, 𝕀, 𝕌, 𝒟
+export chebyshevt, chebyshevu, legendre, ∫, ⨜, ⨍, ChebyshevWeight, 𝕀, 𝕌, 𝒟, ∆
 
 ## Chebyshev & Legendre polynomials
 
@@ -48,4 +48,4 @@ const ℝ = Line()
 const 𝕌 = Circle()
 
 𝒟 = Derivative()
-Δ = Laplacian()
+∆ = Laplacian()

--- a/src/Extras/poetry.jl
+++ b/src/Extras/poetry.jl
@@ -3,7 +3,7 @@
 #####
 
 
-export chebyshevt, chebyshevu, legendre, ∫, ⨜, ⨍, ChebyshevWeight, 𝕀, 𝕌, 𝒟, ∆
+export chebyshevt, chebyshevu, legendre, ∫, ⨜, ∑, ⨍, ChebyshevWeight, 𝕀, 𝕌, 𝒟, ∆
 
 ## Chebyshev & Legendre polynomials
 
@@ -32,7 +32,7 @@ ChebyshevWeight()=ChebyshevWeight(0)
 ∫(f::Fun)=integrate(f)
 ⨜(f::Fun)=cumsum(f)
 
-for OP in (:Σ,:∮,:⨍,:⨎)
+for OP in (:∑,:∮,:⨍,:⨎)  # ∑ entered by \sum<tab>, not \Sigma<tab>
     @eval $OP(f::Fun)=sum(f)
 end
 

--- a/test/ExtrasTest.jl
+++ b/test/ExtrasTest.jl
@@ -2,6 +2,12 @@ using ApproxFun, Test, DualNumbers
 import ApproxFun: eigs
 
 @testset "Extras" begin
+    @testset "Exported symbols" begin
+        f = Fun()
+        @test ∑(f)==sum(f)==0
+        @test ∆ == Laplacian()
+    end
+
     @testset "Dual numbers" begin
         @test dual(1.5,1) ∈  Segment(dual(1.0,1),dual(2.0))
 

--- a/test/NumberTypeTest.jl
+++ b/test/NumberTypeTest.jl
@@ -1,4 +1,4 @@
-using ApproxFun, ApproxFunOrthogonalPolynomials, Test
+using ApproxFun, Test
 
 @testset "BigFloat" begin
     @testset "BigFloat constructor" begin


### PR DESCRIPTION
This PR exports `∆` and `∑` for `Laplacian()` and `sum()`.  

Note that these symbols are entered by `\increment` and `\sum`, and different from `Δ` (`\Delta`) and `Σ` (`\Sigma`) that are more commonly used as variable names.  Therefore, exporting these symbols do not clutter the namespace.

This PR fixes #760.  Once this PR is merged, the documentation mentioning `Δ` (`\Delta`) as an alias for `Laplacian()` should be updated with `∆` (`\increment`).