### PR TITLE
Define compact show for operators to simplify display for containers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFun"
 uuid = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Extras/show.jl
+++ b/src/Extras/show.jl
@@ -182,16 +182,19 @@ end
 
 ## Operator
 
-summary(B::Operator) =
-    string(typeof(B).name.name)*" : "*string(domainspace(B))*" → "*string(rangespace(B))
+function summary(io::IO, B::Operator)
+    s = string(typeof(B).name.name)*" : "*string(domainspace(B))*" → "*string(rangespace(B))
+    print(io, s)
+end
 
 struct PrintShow
     str
 end
 Base.show(io::IO,N::PrintShow) = print(io,N.str)
 
+show(io::IO, B::Operator) = summary(io, B)
 
-function show(io::IO,B::Operator;header::Bool=true)
+function show(io::IO, ::MIME"text/plain", B::Operator;header::Bool=true)
     header && println(io,summary(B))
     dsp=domainspace(B)
 

--- a/src/Extras/show.jl
+++ b/src/Extras/show.jl
@@ -132,9 +132,10 @@ function show(io::IO,ss::PiecewiseSpace)
     end
 end
 
-summary(ss::ArraySpace) = string(Base.dims2string(length.(axes(ss))), " ArraySpace")
+summarystr(ss::ArraySpace) = string(Base.dims2string(length.(axes(ss))), " ArraySpace")
+summary(io::IO, ss::ArraySpace) = print(io, summarystr(ss))
 function show(io::IO,ss::ArraySpace;header::Bool=true)
-    header && print(io,summary(ss)*":\n")
+    header && print(io,summarystr(ss)*":\n")
     show(io, ss.spaces)
 end
 
@@ -182,10 +183,8 @@ end
 
 ## Operator
 
-function summary(io::IO, B::Operator)
-    s = string(typeof(B).name.name)*" : "*string(domainspace(B))*" → "*string(rangespace(B))
-    print(io, s)
-end
+summarystr(B::Operator) = string(typeof(B).name.name, " : ", domainspace(B), " → ", rangespace(B))
+summary(io::IO, B::Operator) = print(io, summarystr(B))
 
 struct PrintShow
     str
@@ -195,7 +194,7 @@ Base.show(io::IO,N::PrintShow) = print(io,N.str)
 show(io::IO, B::Operator) = summary(io, B)
 
 function show(io::IO, ::MIME"text/plain", B::Operator;header::Bool=true)
-    header && println(io,summary(B))
+    header && println(io, summarystr(B))
     dsp=domainspace(B)
 
     if !isambiguous(domainspace(B)) && (eltype(B) <: Number)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,3 +216,15 @@ end
     u = newton(N, u₀) # perform Newton iteration in function space
     @test u(0.1) ≈ 0.9983370741307388
 end
+
+@testset "show" begin
+    op = Derivative(Chebyshev())
+    io = IOBuffer()
+    @test summary(io, op) isa Nothing
+    @test contains(String(take!(io)), " : $(domainspace(op)) → $(rangespace(op))")
+    show(io, op)
+    @test contains(String(take!(io)), " : $(domainspace(op)) → $(rangespace(op))")
+
+    @test summary(io, ApproxFun.ArraySpace(Chebyshev(), 2)) isa Nothing
+    @test contains(String(take!(io)), "ArraySpace")
+end


### PR DESCRIPTION
With this PR
```julia
julia> D = Derivative(Ultraspherical(1))
ConcreteDerivative : Ultraspherical(1) → Ultraspherical(2)
 ⋅  2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0  ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱

julia> [D, D]
2-element Vector{ApproxFunBase.ConcreteDerivative{Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Int64, Float64}}:
 ConcreteDerivative : Ultraspherical(1) → Ultraspherical(2)
 ConcreteDerivative : Ultraspherical(1) → Ultraspherical(2)
```
whereas on master
```julia
julia> [D, D]
2-element Vector{ApproxFunBase.ConcreteDerivative{Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}, Int64, Float64}}:
 ConcreteDerivative : Ultraspherical(1) → Ultraspherical(2)
 ⋅  2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0  ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
 ConcreteDerivative : Ultraspherical(1) → Ultraspherical(2)
 ⋅  2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0   ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   2.0  ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
```

Usually, in a collection, one doesn't want to see the entire matrix representation of each operator. Moreover, this makes the compact `show` more performant.
```julia
julia> @btime show($(IOBuffer()), $([D, D]));
  750.835 μs (8320 allocations: 326.25 KiB) # master
  200.370 μs (113 allocations: 18.83 KiB) # PR
```