### PR TITLE
Fix `show` for `QuotientSpace`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFun"
 uuid = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Extras/show.jl
+++ b/src/Extras/show.jl
@@ -115,7 +115,7 @@ end
 function show(io::IO, m::MIME"text/plain", s::QuotientSpace)
     show(io,s.space)
     print(io," /\n")
-    show(io, m, s.bcs)
+    show(io, m, s.bcs, header = false)
 end
 
 

--- a/src/Extras/show.jl
+++ b/src/Extras/show.jl
@@ -109,7 +109,13 @@ end
 function show(io::IO,s::QuotientSpace)
     show(io,s.space)
     print(io," /\n")
-    show(io,s.bcs;header=false)
+    show(io,s.bcs)
+end
+
+function show(io::IO, m::MIME"text/plain", s::QuotientSpace)
+    show(io,s.space)
+    print(io," /\n")
+    show(io, m, s.bcs)
 end
 
 
@@ -191,7 +197,7 @@ struct PrintShow
 end
 Base.show(io::IO,N::PrintShow) = print(io,N.str)
 
-show(io::IO, B::Operator) = summary(io, B)
+show(io::IO, B::Operator; kw...) = summary(io, B)
 
 function show(io::IO, ::MIME"text/plain", B::Operator;header::Bool=true)
     header && println(io, summarystr(B))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,4 +227,10 @@ end
 
     @test summary(io, ApproxFun.ArraySpace(Chebyshev(), 2)) isa Nothing
     @test contains(String(take!(io)), "ArraySpace")
+
+    Q = QuotientSpace(Dirichlet(Chebyshev()))
+    @test startswith(repr(Q), "Chebyshev() /")
+    show(io, MIME"text/plain"(), Q)
+    s = String(take!(io))
+    @test startswith(s, "Chebyshev() /")
 end


### PR DESCRIPTION
Fix for bug introduced by https://github.com/JuliaApproximation/ApproxFun.jl/pull/781. After this, the following work:
```julia
julia> QuotientSpace(Dirichlet(Chebyshev()))
Chebyshev() /
 1.0  -1.0  1.0  -1.0  1.0  -1.0  1.0  -1.0  1.0  -1.0  ⋯
 1.0   1.0  1.0   1.0  1.0   1.0  1.0   1.0  1.0   1.0  ⋯

julia> show(Q)
Chebyshev() /
ConcreteDirichlet : Chebyshev() → 2-element ArraySpace:
ConstantSpace{DomainSets.Point{Float64}, Float64}[ConstantSpace(Point(-1.0)), ConstantSpace(Point(1.0))]
```