### PR TITLE
limit docstring of `values` to Fun`

### DIFF
--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -194,7 +194,7 @@ space
 ```
 
 ```@docs
-ApproxFun.values
+values(::Fun)
 ```
 
 ```@docs


### PR DESCRIPTION
Don't include the generic `Base.values` docstrings