### PR TITLE
Remove explicit CI tests on `v1.8`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '^1.8.0-0'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Now that `v1` points to `v1.8`