### PR TITLE
Doctests for ApproxFun and ApproxFunBase

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,8 +29,6 @@ for (example, included) in [
 end
 
 makedocs(
-            doctest = false,
-            clean = true,
             format = Documenter.HTML(),
             sitename = "ApproxFun.jl",
             authors = "Sheehan Olver",

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -290,3 +290,7 @@ Multiplication
 ```@docs
 Neumann
 ```
+
+```@docs
+PartialInverseOperator
+```

--- a/docs/src/usage/constructors.md
+++ b/docs/src/usage/constructors.md
@@ -1,12 +1,14 @@
-```@setup using-pkgs
-using ApproxFun
+```@meta
+DocTestSetup  = quote
+    using ApproxFun, LinearAlgebra
+end
 ```
 
 # Constructors
 
 `Fun`s in ApproxFun are instances of Julia types with one field to store coefficients and another to describe the function space. Similarly, each function space has one field describing its domain, or another function space. Let's explore:
 
-```@repl using-pkgs
+```@repl
 x = Fun(identity,-1..1);
 f = exp(x);
 g = f/sqrt(1-x^2);
@@ -16,7 +18,7 @@ space(g)  # Output is pretty version of JacobiWeight(-0.5,-0.5,Interval(-1.0,1.0
 
 The absolute value is another case where the space of the output is inferred from the operation:
 
-```@repl using-pkgs
+```@repl
 f = Fun(x->cospi(5x),-1..1);
 g = abs(f);
 space(f)
@@ -51,7 +53,7 @@ x = Fun()
 
 It is sometimes necessary to specify coefficients explicitly.  This is possible via specifying the space followed by a vector of coefficients:
 
-```@repl using-pkgs
+```@repl
 f = Fun(Taylor(), [1,2,3]);  # represents 1 + 2z + 3z^2
 f(0.1)
 1 + 2*0.1 + 3*0.1^2
@@ -77,7 +79,7 @@ For example, if we are in the two dimensional CosSpace space and we have coeffic
 
 This is illustrated in the following code:
 
-```@repl using-pkgs
+```@repl
 f = Fun(CosSpace()^2, [1,2,3])
 f(1,2)
 1cos(0*1)*cos(0*2) + 2cos(0*1)*cos(1*2) + 3cos(1*1)*cos(0*2)

--- a/docs/src/usage/equations.md
+++ b/docs/src/usage/equations.md
@@ -1,5 +1,7 @@
-```@setup using-pkgs
-using ApproxFun, LinearAlgebra
+```@meta
+DocTestSetup  = quote
+    using ApproxFun, LinearAlgebra
+end
 ```
 
 # Linear equations
@@ -12,7 +14,7 @@ Linear equations such as ordinary and partial differential equations, fractional
 
 where we want a solution that is periodic on ``[0,2π)``.  This can be solved succinctly as follows:
 
-```@repl using-pkgs
+```@repl
 b = Fun(cos,Fourier());
 c = 0.1; u = (𝒟+c*I) \ b;
 u(0.6)
@@ -29,7 +31,7 @@ As another example, consider the Fredholm integral equation
 
 We can solve this equation as follows:
 
-```@repl using-pkgs
+```@repl
 Σ = DefiniteIntegral(Chebyshev()); x = Fun();
 u = (I+exp(x)*Σ[cos(x)]) \ cos(exp(x));
 u(0.1)
@@ -50,7 +52,7 @@ Incorporating boundary conditions into differential equations is important so th
 
 To pose this in ApproxFun, we want to find a `u` such that `Evaluation(0)*u == 1` and `(𝒟 - t)*u == 0`.  This is accomplished via:
 
-```@repl using-pkgs
+```@repl
 t = Fun(0..1);
 u = [Evaluation(0); 𝒟-t] \ [1;0];
 u(0)
@@ -70,7 +72,7 @@ A common usage is two-point boundary value problems. Consider the singularly per
 
 This can be solved in ApproxFun via:
 
-```@repl using-pkgs
+```@repl
 ϵ = 1/70; x = Fun();
 u = [Evaluation(-1);
      Evaluation(1);
@@ -82,7 +84,7 @@ Note in this case the space is inferred from the variable coefficient `x`.
 
 This ODE can also be solved using the `Dirichlet` operator:
 
-```@repl using-pkgs
+```@repl
 x = Fun();
 u = [Dirichlet();
      1/70*𝒟^2-x*𝒟+I] \ [[1,2],0];

--- a/docs/src/usage/operators.md
+++ b/docs/src/usage/operators.md
@@ -1,5 +1,7 @@
-```@setup using-pkgs
-using ApproxFun, LinearAlgebra
+```@meta
+DocTestSetup  = quote
+    using ApproxFun, LinearAlgebra
+end
 ```
 
 # Operators
@@ -12,7 +14,7 @@ Note that the size of an operator is specified by the dimension of the domain an
 
 Differential and integral operators are perhaps the most useful type of operators in mathematics.  Consider the derivative operator on `CosSpace`:
 
-```@repl using-pkgs
+```@repl
 D = Derivative(CosSpace())
 f = Fun(θ->cos(cos(θ)), CosSpace());
 fp = D*f;
@@ -49,7 +51,7 @@ D[k,j] ≈ (D*ej).coefficients[k] ≈ -k
 
 The `Chebyshev` space has the property that its derivatives are given by ultraspherical spaces:
 
-```@repl using-pkgs
+```@repl
 Derivative(Chebyshev())
 ```
 
@@ -59,7 +61,7 @@ A particularly useful class of operators are _functionals_, which map from funct
 
 As an example, the evaluation functional `f(0)` on `CosSpace` has the form:
 
-```@repl using-pkgs
+```@repl
 B = Evaluation(CosSpace(),0)
 B*f ≈ f(0)
 ```
@@ -68,7 +70,7 @@ As can be seen from the output, `rangespace(B)` is a `ConstantSpace(Point(0))`, 
 
 Closely related to functionals are operators with finite-dimensional range.  For example, the `Dirichlet` operator represents the restriction of a space to its boundary.  In the case, of `Chebyshev()`, this amounts to evaluation at the endpoints `±1`:
 
-```@repl using-pkgs
+```@repl
 B = Dirichlet(Chebyshev())
 size(B)
 B*Fun(exp)
@@ -79,7 +81,7 @@ B*Fun(exp) ≈ Fun([exp(-1),exp(1)])
 
 A `Multiplication` operator sends a `Fun` to a `Fun` in the corresponding space by multiplying a given function. The `Multiplication` operators are presented in matrix form in `ApproxFun`.
 
-```@repl using-pkgs
+```@repl
 x = Fun();
 M = Multiplication(1 + 2x + x^2, Chebyshev())
 (M * x).coefficients == ((1 + 2x + x^2) * x).coefficients == M[1:4,1:2] * x.coefficients
@@ -87,7 +89,7 @@ M = Multiplication(1 + 2x + x^2, Chebyshev())
 
 It is possible for domain space and range space to be different under `Mulitplication`.
 
-```@repl using-pkgs
+```@repl
 c = Fun(θ -> cos(θ), CosSpace());
 Multiplication(c, SinSpace())
 ```
@@ -116,14 +118,14 @@ where ``f_0 = 0``.
 Operators can be algebraically manipulated, provided that the domain and range spaces are compatible, or can be made compatible.  As a simple example, we can add the second derivative of a Fourier space to the
 identity operator:
 
-```@repl using-pkgs
+```@repl
 D2 = Derivative(Fourier(),2)
 D2 + I
 ```
 
 When the domain and range space are not the same, the identity operator becomes a conversion operator.  That is, to represent `D+I` acting on the Chebyshev space, we would do the following:
 
-```@repl using-pkgs
+```@repl
 D = Derivative(Chebyshev())
 C = Conversion(Chebyshev(),Ultraspherical(1))
 D + C
@@ -139,7 +141,7 @@ Now consider the Fredholm integral operator of the second kind:
 
 We can construct this using
 
-```@repl using-pkgs
+```@repl
 x = Fun();
 Σ = DefiniteIntegral(Chebyshev())
 L = I + exp(x)*Σ
@@ -167,7 +169,7 @@ Note that `Σ*exp(x)` applies the operator to a function.  To construct the oper
 
 It is often more convenient to not specify a space explicitly, but rather infer it when the operator is used.  For example, we can construct `Derivative()`, which has the alias `𝒟`, and represents the first derivative on any space:
 
-```@repl using-pkgs
+```@repl
 f = Fun(cos,Chebyshev(0..1)); (𝒟*f)(0.1)
 f = Fun(cos,Fourier()); (𝒟*f)(0.1)
 ```
@@ -176,7 +178,7 @@ Behind the scenes, `Derivative()` is equivalent to `Derivative(UnsetSpace(),1)`.
 
 This promotion of the domain space happens even when operators have spaces attached.  This facilitates the following construction:
 
-```jldoctest; setup=:(using ApproxFun)
+```jldoctest
 julia> D = Derivative(Chebyshev());
 
 julia> D^2

--- a/docs/src/usage/operators.md
+++ b/docs/src/usage/operators.md
@@ -176,7 +176,7 @@ Behind the scenes, `Derivative()` is equivalent to `Derivative(UnsetSpace(),1)`.
 
 This promotion of the domain space happens even when operators have spaces attached.  This facilitates the following construction:
 
-```jldoctest
+```jldoctest; setup=:(using ApproxFun)
 julia> D = Derivative(Chebyshev());
 
 julia> D^2
@@ -194,7 +194,7 @@ ConcreteDerivative : Chebyshev() → Ultraspherical(2)
  ⋅  ⋅   ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
 ```
 
-Note that `rangespace(D) ≠ Chebyshev()`, hence the operators are not compatible.  Therefore, it has thrown away its domain space, and thus this is equivalent to `Derivative(rangespace(D))*D`.
+Note that `rangespace(D) ≠ Chebyshev()`, hence the operators are not compatible.  Therefore, it has thrown away its domain space, and thus this is equivalent to `Derivative(rangespace(D))*D`.
 
 ## Concatenating operators
 

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -385,7 +385,7 @@ reverseorientation(::Fun)
     canonicalspace(s::Space)
 
 Return a space that is used as a default to implement missing functionality,
-e.g., evaluation.  Implement a `Conversion` operator or override `coefficients` to support this.
+e.g., evaluation.  Implement a [`Conversion`](@ref) operator or override `coefficients` to support this.
 
 # Examples
 ```jldoctest
@@ -454,7 +454,7 @@ itransform(::Space, ::AbstractVector)
 """
     evaluate(coefficients::AbstractVector, sp::Space, x)
 
-Evaluates the expansion at a point `x` that lies in `domain(sp)`.
+Evaluate the expansion at a point `x` that lies in `domain(sp)`.
 If `x` is not in the domain, the returned value will depend on the space,
 and should not be relied upon. See [`extrapolate`](@ref) to evaluate a function
 at a value outside the domain.
@@ -473,7 +473,7 @@ spacescompatible(::Space,::Space)
 """
     conversion_type(a::Space,b::Space)
 
-Return a `Space` that has a banded conversion operator to both `a` and `b`.
+Return a `Space` that has a banded [`conversion`](@ref) operator to both `a` and `b`.
 Override `ApproxFun.conversion_rule` when adding new `Conversion` operators.
 """
 conversion_type(::Space,::Space)
@@ -491,14 +491,14 @@ dimension(::Space)
 """
     Operator{T}
 
-is an abstract type to represent linear operators between spaces.
+Abstract type to represent linear operators between spaces.
 """
 Operator
 
 """
     domainspace(op::Operator)
 
-gives the domain space of `op`.  That is, `op*f` will first convert `f` to
+Return the domain space of `op`.  That is, `op*f` will first convert `f` to
 a `Fun` in the space `domainspace(op)` before applying the operator.
 """
 domainspace(::Operator)
@@ -506,7 +506,7 @@ domainspace(::Operator)
 """
     rangespace(op::Operator)
 
-gives the range space of `op`.  That is, `op*f` will return a `Fun` in the
+Return the range space of `op`.  That is, `op*f` will return a `Fun` in the
 space `rangespace(op)`, provided `f` can be converted to a `Fun` in
 `domainspace(op)`.
 """
@@ -546,7 +546,7 @@ choosedomainspace(::Operator,::Space)
 
 
 """
-    op[k,j]
+    (op::Operator)[k,j]
 
 Return the `k`th coefficient of `op*Fun([zeros(j-1);1],domainspace(op))`.
 """
@@ -554,9 +554,9 @@ getindex(::Operator,k,j)
 
 
 """
-    op[f::Fun]
+    (op::Operator)[f::Fun]
 
-constructs the operator `op * Multiplication(f)`, that is, it multiplies on the right
+Construct the operator `op * Multiplication(f)`, that is, it multiplies on the right
 by `f` first.  Note that `op * f` is different: it applies `op` to `f`.
 
 # Examples
@@ -567,10 +567,10 @@ Fun(Chebyshev(), [0.0, 1.0])
 julia> D = Derivative()
 ConcreteDerivative : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()
 
-julia> D2 = D[x]
+julia> Dx = D[x] # construct the operator y -> d/dx * (x * y)
 TimesOperator : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()
 
-julia> twox = D2 * x
+julia> twox = Dx * x # Evaluate d/dx * (x * x)
 Fun(Ultraspherical(1), [0.0, 1.0])
 
 julia> twox(0.1) ≈ 2 * 0.1
@@ -584,5 +584,8 @@ getindex(::Operator,::Fun)
     Conversion(fromspace::Space,tospace::Space)
 
 Represent a conversion operator between `fromspace` and `tospace`, when available.
+
+See also [`PartialInverseOperator`](@ref) that might be able to represent the inverse,
+even if this isn't banded.
 """
 Conversion(::Space,::Space)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,10 +7,12 @@ using Aqua
 end
 
 using Documenter
+DocMeta.setdocmeta!(ApproxFunBase, :DocTestSetup, :(using ApproxFun); recursive=true)
 DocMeta.setdocmeta!(ApproxFun, :DocTestSetup, :(using ApproxFun); recursive=true)
 
 @testset "doctests" begin
-    doctest(ApproxFun, manual = false)
+    doctest(ApproxFun)
+    doctest(ApproxFunBase, manual=false)
 end
 
 include("ReadmeTest.jl")
@@ -186,13 +188,12 @@ end
     @test minimum(r) ≥ -5
 end
 
-f=Fun(exp)
-x=sample(f,100000)
-x=sample(f,100000)
-@time x=sample(f,100000)
-println("Sample: Time should be ~0.13")
-
-
+@testset "sample" begin
+    f=Fun(exp)
+    x=sample(f,100000)
+    x=sample(f,100000)
+    @time x=sample(f,100000)
+end
 
 @testset "Null space" begin
     d=ChebyshevInterval()


### PR DESCRIPTION
This lets one add doctests to `ApproxFunBase`, while ensuring that they are tested after loading `ApproxFun` so that the necessary spaces are available.