### PR TITLE
Use `ApproxFunBaseTest` in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,8 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 AbstractFFTs = "1.0"
-ApproxFunBase = "0.6, 0.7"
+ApproxFunBase = "0.7"
+ApproxFunBaseTest = "0.1"
 ApproxFunFourier = "0.3"
 ApproxFunOrthogonalPolynomials = "0.5"
 ApproxFunSingularities = "0.3"
@@ -36,10 +37,11 @@ SpecialFunctions = "1.1, 2"
 julia = "1.6"
 
 [extras]
+ApproxFunBaseTest = "a931bfaf-0cfd-4a5c-b69c-bf2eed002b43"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Documenter", "Random", "Test"]
+test = ["ApproxFunBaseTest", "Aqua", "Documenter", "Random", "Test"]

--- a/test/ExtrasTest.jl
+++ b/test/ExtrasTest.jl
@@ -1,5 +1,7 @@
-using ApproxFun, Test, DualNumbers
-import ApproxFun: eigs
+using ApproxFun
+using ApproxFun: eigs
+using Test
+using DualNumbers
 
 @testset "Extras" begin
     @testset "Dual numbers" begin

--- a/test/FractionalTest.jl
+++ b/test/FractionalTest.jl
@@ -1,8 +1,8 @@
 using ApproxFun, Test
-    import ApproxFunBase: testfunctional, testbandedoperator
+using ApproxFunBaseTest: testfunctional, testbandedoperator
 
 @testset "Fractional" begin
-    @testset "Jupyer example" begin
+    @testset "Jupyter example" begin
         S = Legendre() ⊕ JacobiWeight(0.5,0.,Ultraspherical(1))
         @time Q½ = LeftIntegral(S,0.5)
         @time testbandedoperator(Q½)
@@ -109,8 +109,8 @@ using ApproxFun, Test
 
     ## Test for bug
 
-    QL = LeftIntegral(0.5)	: Legendre()					→	JacobiWeight(0.5,0.,Ultraspherical(1))
-    QU = LeftIntegral(0.5)	: JacobiWeight(0.5,0.,Ultraspherical(1))	→	Legendre()
+    QL = LeftIntegral(0.5)	: Legendre() →	JacobiWeight(0.5,0.,Ultraspherical(1))
+    QU = LeftIntegral(0.5)	: JacobiWeight(0.5,0.,Ultraspherical(1)) → Legendre()
 
 
     λ=0.25

--- a/test/NumberTypeTest.jl
+++ b/test/NumberTypeTest.jl
@@ -1,4 +1,7 @@
-using ApproxFun, ApproxFunOrthogonalPolynomials, Test, FFTW
+using ApproxFun
+using ApproxFunOrthogonalPolynomials
+using Test
+using FFTW
 
 @testset "BigFloat" begin
     @testset "BigFloat constructor" begin

--- a/test/ReadmeTest.jl
+++ b/test/ReadmeTest.jl
@@ -1,4 +1,7 @@
-using ApproxFun, SpecialFunctions, LinearAlgebra, Test
+using ApproxFun
+using SpecialFunctions
+using LinearAlgebra
+using Test
 
 const EXAMPLES_DIR = joinpath(dirname(dirname(pathof(ApproxFun))), "examples")
 


### PR DESCRIPTION
Also, drop support for `ApproxFunBase` versions <v0.7.