### PR TITLE
Ignore ApproxFunBaseTest as a dep

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,8 @@ using BlockBandedMatrices: blockbandwidths, subblockbandwidths
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(ApproxFun, ambiguities=false, undefined_exports=false)
+    Aqua.test_all(ApproxFun, ambiguities=false, undefined_exports=false,
+        stale_deps=(; ignore=[:ApproxFunBaseTest]))
 end
 
 using Documenter


### PR DESCRIPTION
This lets one carry out downstream tests in ApproxFunBaseTest by developing the package, without being flagged by Aqua.