### PR TITLE
fixed jacobian(f::Fun)

### DIFF
--- a/src/Extras/autodifferentiation.jl
+++ b/src/Extras/autodifferentiation.jl
@@ -61,7 +61,7 @@ last(d::DualFun) = DualFun(last(d.f),Evaluation(rangespace(d.J),rightendpoint)*d
 
 jacobian(d::DualFun) = d.J
 jacobian(a::Number) = zero(a)
-jacobian(f::Fun) = Operator(I,space(f))
+jacobian(f::Fun) = zero(f)
 
 promote_rule(::Type{DF},::Type{T}) where {DF<:DualFun,T<:Number}=DualFun
 convert(::Type{DualFun},b::Number) = DualFun(b,0)


### PR DESCRIPTION
Test case (requires also https://github.com/JuliaApproximation/ApproxFunBase.jl/pull/479):
    using ApproxFun

    xdom = Chebyshev(-1..1)
    ydom = Chebyshev(-1..1)
    domain = xdom * ydom
    x,y = Fun(identity, domain)
    Dx = Derivative(Chebyshev()^2, [1,0])
    Dy = Derivative(Chebyshev()^2, [0,1])

    N(u, v) = [
        2*u - x;
        3*v + y
    ]

    u0 = one(x) * one(y)
    v0 = one(x) * one(y)
    u, v = newton(N, [u0, v0])

Bug report:
https://github.com/JuliaApproximation/ApproxFun.jl/issues/887