### PR TITLE
Don't test on v1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '~1.10.0-0'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Looking at the somewhat random test failure in https://github.com/JuliaApproximation/ApproxFun.jl/actions/runs/5701500758/job/15452279928, perhaps it's best to wait for v1.10 to become more stable