### PR TITLE
Add inverse chebyshev transform plan for Dual

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFun"
 uuid = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
-version = "0.13.22"
+version = "0.13.23"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/ext/ApproxFunDualNumbersExt.jl
+++ b/ext/ApproxFunDualNumbersExt.jl
@@ -5,9 +5,9 @@ using ApproxFun
 using ApproxFun: TransformPlan, ITransformPlan
 import ApproxFunBase: valsdomain_type_promote
 using DomainSets
-import FastTransforms: ChebyshevTransformPlan, plan_chebyshevtransform,
-                        plan_chebyshevtransform!, plan_ichebyshevtransform,
-                        plan_ichebyshevtransform!
+import FastTransforms: ChebyshevTransformPlan, IChebyshevTransformPlan,
+                        plan_chebyshevtransform, plan_chebyshevtransform!,
+                        plan_ichebyshevtransform, plan_ichebyshevtransform!
 
 # Dual number support. Should there be realpart and dualpart of Space and Domain?
 DualNumbers.realpart(f::Fun{S,T}) where {S,T<:Dual} = Fun(space(f),realpart.(coefficients(f)))
@@ -45,6 +45,7 @@ plan_ichebyshevtransform(v::AbstractVector{D}, ::Val{kind}) where {D<:Dual,kind}
 
 
 Base.:(*)(P::ChebyshevTransformPlan,v::AbstractVector{<:Dual}) = dual.(P*realpart.(v),P*dualpart.(v))
+Base.:(*)(P::IChebyshevTransformPlan,v::AbstractVector{<:Dual}) = dual.(P*realpart.(v),P*dualpart.(v))
 
 #TODO: Hardy{false}
 for (OP,TransPlan) in ((:plan_transform,:TransformPlan),(:plan_itransform,:ITransformPlan)),

--- a/test/ExtrasTest.jl
+++ b/test/ExtrasTest.jl
@@ -56,6 +56,9 @@ include(joinpath(@__DIR__, "testutils.jl"))
         f=Fun(x->exp(dual(x,1)),-1..1)
         @test coefficients(realpart(f)) == realpart.(coefficients(f))
         @test coefficients(dualpart(f)) == dualpart.(coefficients(f))
+
+        # Test inverse Chebyshev transform for dual numbers
+        @test all(absdual.(transform(space(f),values(f)) - coefficients(f)) .< 10eps())
     end
 
     @testset "Eig test #336" begin


### PR DESCRIPTION
I have added a method for the inverse Chebyshev transform plan on dual vectors to support transforming functionals with dual number coefficients to the value space.

This issue came up when trying to multiply two functionals with enough non-zero dual coefficients to convert to the value space.