### PR TITLE
Set jacobian of Fun to ZeroOperator

### DIFF
--- a/src/Extras/autodifferentiation.jl
+++ b/src/Extras/autodifferentiation.jl
@@ -61,7 +61,7 @@ last(d::DualFun) = DualFun(last(d.f),Evaluation(rangespace(d.J),rightendpoint)*d
 
 jacobian(d::DualFun) = d.J
 jacobian(a::Number) = zero(a)
-jacobian(f::Fun) = Operator(I,space(f))
+jacobian(f::Fun) = zero(Operator(I,space(f)))
 
 promote_rule(::Type{DF},::Type{T}) where {DF<:DualFun,T<:Number}=DualFun
 convert(::Type{DualFun},b::Number) = DualFun(b,0)

--- a/test/ExtrasTest.jl
+++ b/test/ExtrasTest.jl
@@ -123,8 +123,7 @@ include(joinpath(@__DIR__, "testutils.jl"))
                 u2' - u2*u2;
             ]
 
-        # note takes a few more iterations to converge to accuracy
-        u1,u2 = newton(N_ind, [u1,u2], maxiterations=25)
+        u1,u2 = newton(N_ind, [u1,u2])
 
         u1_exact = -1 / (x - 2)
         u2_exact = -1 / (x + 2)


### PR DESCRIPTION
The jacobian of a plain Functional should be the `ZeroOperator`. This is what was causing the independent variable test for the newton iteration to take considerably more iterations than if each dimension was solved in isolation.