### PR TITLE
Disable tests on `macOS-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
+          # - macOS-latest # FastTransforms.jl is currently broken on macOS-latest
           - windows-latest
         arch:
           - x64


### PR DESCRIPTION
`FastTransforms.jl` is currently broken on `macOS-latest`, which leads to test failures in this package. The tests may be enabled again when the upstream package is fixed.